### PR TITLE
Keep 2.4.7 Focus Visible at level AA

### DIFF
--- a/_data/wcag22.json
+++ b/_data/wcag22.json
@@ -3716,7 +3716,7 @@
 					"2.1",
 					"2.2"
 				],
-				"level": "A",
+				"level": "AA",
 				"handle": "Focus Visible",
 				"title": "Any keyboard operable user interface has a mode of operation where the keyboard focus indicator is visible.",
 				"techniques": [


### PR DESCRIPTION
While counting SCs for a 2.2 presentation, I noticed that [2.4.7 Focus Visible is displaying as level A](https://www.w3.org/WAI/WCAG22/quickref/#focus-visible) on the quickref after the WCAG 2.2 SCs were added. Since the 2.4.7 change from AA to A isn't a part of the final 2.2 recommendations, the quickref's `wcag22.json` needs a small update.

This pull request returns 2.4.7 Focus Visible to level AA.

Note: if building this locally while running a newer version of Ruby, adding `gem 'webrick'` to the bottom of `Gemfile` will be required to get `bundle exec jekyll serve --watch` to run. 