### PR TITLE
Correct technique link

### DIFF
--- a/_data/wcag22.json
+++ b/_data/wcag22.json
@@ -4055,7 +4055,7 @@
 				{
 					"sufficient": [
 					{
-						"id": "TECH:G159",
+						"id": "TECH:G195",
 						"title": "Using an author-supplied, visible focus indicator"
 					},
 					{


### PR DESCRIPTION
Point the link for "Using an author-supplied, visible focus indicator" to G195 (the correct link) instead of G159