### PR TITLE
Update and clean up some footer wording

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -6,7 +6,7 @@
       <a href="https://www.w3.org/People/shadi/">Shadi Abou-Zahra</a> (Project Lead),
       <a href="https://www.w3.org/People/yatil/">Eric Eggert</a>,
       Gregg Vanderheiden, Loretta Guarino Reid, Ben Caldwell, <a href="https://www.w3.org/People/Shawn/">Shawn Lawton Henry</a>, Gez Lemon.<br>
-      The {{ site.time | date:"%Y" }} redesign was developed by the Education and Outreach Working Group (<a href="https://www.w3.org/WAI/EO/">EOWG</a>) and the Web Content Accessibility Guidelines Working Group (<a href="https://www.w3.org/WAI/GL/">WCAG WG</a>),  with support from the <a href="https://www.w3.org/WAI/DEV/">WAI-DEV project</a>, a project of the European Commission IST Programme.</p>
+      The 2016 redesign was developed by the Education and Outreach Working Group (<a href="https://www.w3.org/WAI/EO/">EOWG</a>) and the Web Content Accessibility Guidelines Working Group (<a href="https://www.w3.org/WAI/GL/">WCAG WG</a>),  with support from the <a href="https://www.w3.org/WAI/DEV/">WAI-DEV project</a>, a project of the European Commission IST Programme.</p>
 
    <nav aria-label="Footer Navigation" class="footer-nav">
       <ul>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -2,7 +2,11 @@
    <hr>
    <h2 id="wai_footerheading" class="sr-only">Document Information</h2>
    <p><strong>Status:</strong>{%if site.status == "draft" %}<strong> Draft.</strong>{% endif %} Updated {{ site.time | date:"%d %b %Y" }}. Version {{site.version}}.<br />
-      Lead Developer: <a href="https://www.w3.org/People/yatil/">Eric Eggert</a> (W3C). Project Lead: <a href="https://www.w3.org/People/shadi/">Shadi Abou-Zahra</a> (W3C).<br>Previous editors and developers: Gregg Vanderheiden, Loretta Guarino Reid, Ben Caldwell, <a href="https://www.w3.org/People/Shawn/">Shawn Lawton Henry</a>, Gez Lemon.<br>The {{ site.time | date:"%Y" }} redesign was developed by the Education and Outreach Working Group (<a href="https://www.w3.org/WAI/EO/">EOWG</a>) and the Web Content Accessibility Guidelines Working Group (<a href="https://www.w3.org/WAI/GL/">WCAG WG</a>),  with support from the <a href="https://www.w3.org/WAI/DEV/">WAI-DEV project</a>, a project of the European Commission IST Programme.</p>
+      Previous editors and developers:
+      <a href="https://www.w3.org/People/shadi/">Shadi Abou-Zahra</a> (Project Lead),
+      <a href="https://www.w3.org/People/yatil/">Eric Eggert</a>,
+      Gregg Vanderheiden, Loretta Guarino Reid, Ben Caldwell, <a href="https://www.w3.org/People/Shawn/">Shawn Lawton Henry</a>, Gez Lemon.<br>
+      The {{ site.time | date:"%Y" }} redesign was developed by the Education and Outreach Working Group (<a href="https://www.w3.org/WAI/EO/">EOWG</a>) and the Web Content Accessibility Guidelines Working Group (<a href="https://www.w3.org/WAI/GL/">WCAG WG</a>),  with support from the <a href="https://www.w3.org/WAI/DEV/">WAI-DEV project</a>, a project of the European Commission IST Programme.</p>
 
    <nav aria-label="Footer Navigation" class="footer-nav">
       <ul>
@@ -17,7 +21,10 @@
    </section>
    <!-- end footer-nav -->
    <section class="copyright" aria-label="Copyright Notice">
-      <p>Copyright &#xA9; {{ site.time | date:"%Y" }} W3C <sup>&#xAE;</sup> (<a href="https://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>, <a href="https://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>, <a href="https://www.keio.ac.jp/">Keio</a>, <a href="https://ev.buaa.edu.cn/">Beihang</a>) <a href="/Consortium/Legal/ipr-notice">Usage policies apply</a>.</p>
+      <p>
+         Copyright &#xA9; {{ site.time | date:"%Y" }} <a href="https://w3.org">W3C</a> <sup>&#xAE;</sup>.
+         See <a href="https://www.w3.org/WAI/about/using-wai-material/">Permission to Use WAI Material</a>.
+      </p>
    </section>
    <!-- end copyright -->
    <!-- Piwik -->

--- a/index.html
+++ b/index.html
@@ -70,8 +70,7 @@ button: 1
         <p>We welcome feedback and suggestions:</p>
         <ul>
           <li>This resource — <a href="https://github.com/w3c/wai-wcag-quickref/issues/">report bugs</a> and contribute directly to the <a href="https://github.com/w3c/wai-wcag-quickref">Github repository</a></li>
-          <li>Techniques — contribute <a href="https://www.w3.org/WAI/GL/WCAG20/TECHS-SUBMIT/">new WCAG techniques</a></li>
-          <li>Other — contribute corrections, updates, or new information related to techniques, failures, or other WCAG documentation, per the <a href="https://www.w3.org/WAI/WCAG20/comments/">instructions for commenting</a></li>
+          <li><a href="https://www.w3.org/WAI/standards-guidelines/wcag/commenting/">Instructions for Commenting on WCAG 2 Documents</a></li>
         </ul>
       </div>
     </div>


### PR DESCRIPTION
This implements some edits to the contribute box and footer include suggested by @iadawn.

One other thing I noticed that we might want to address: "The 2025 redesign" is programmatically referencing the current year, while I suspect it should reference a specific year in the past, especially considering it mentions the EOWG which was closed in 2024. Any idea which year it should actually refer to?

![Preview of the changes in the PR, impacting the Contribute box and footer.](https://github.com/user-attachments/assets/a5ab6119-bfa6-420c-995e-653c58952f86)
