### PR TITLE
Remove unused dependencies and theme

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,2 @@
 source 'https://rubygems.org'
 gem 'github-pages', group: :jekyll_plugins
-gem 'autoprefixer-rails'
-gem 'jekyll-assets'
-gem 'jekyll-github-metadata'

--- a/_config.yml
+++ b/_config.yml
@@ -17,6 +17,7 @@ lsi: false
 
 # Build settings
 markdown: kramdown
+theme: null # See https://github.com/github/pages-gem/issues/613#issuecomment-478707278
 
 repository: 'w3c/wai-wcag-quickref'
 


### PR DESCRIPTION
This removes dependencies from the Gemfile that don't seem to be required for the build at all.

Tested via `bundle clean`, and also via a completely new checkout that only ever ran `bundle install` from this branch, where it's evident that 2 of the 3 gems are no longer installed. (`jekyll-github-metadata` is still installed, and is presumably already a dependency of `github-pages`.) The build still produces identical output to before.

This also explicitly sets `theme: null`, which is evidently required to override default behavior of the `github-pages` gem, which is what caused the `assets/style.css` to be output (which we don't use, and included a whole bunch of CSS not located in our codebase).