### PR TITLE
Update to read techniques instead of techniquesHtml from wcag22.json

### DIFF
--- a/_data/wcag22.json
+++ b/_data/wcag22.json
@@ -70,35 +70,391 @@
                   ]
                 }
               ],
-              "techniquesHtml": {
+              "techniques": {
                 "sufficient": [
                   {
-                    "title": "Situation A: If a short description can serve the same purpose and present the same\n               information as the non-text content:",
-                    "content": "<ul>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G94\">G94: Providing short text alternative for non-text content that serves the same purpose and presents the same information as the non-text content</a> using one of the following \n                  <strong>\n                     <a href=\"#text-equiv-all-situation-a-shorttext\">Short text alternative techniques for Situation A</a>\n                  </strong>:\n               </li>\n            </ul>\n            <p id=\"text-equiv-all-situation-a-shorttext\">\n               <strong>Short text alternative techniques for Situation A</strong>:\n            </p>\n            <ul id=\"text-equiv-all-situation-a-shorttext-techs\">\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/aria/ARIA6\">ARIA6: Using aria-label to provide labels for objects</a>\n               </li>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/aria/ARIA10\">ARIA10: Using aria-labelledby to provide a text alternative for non-text content</a>\n               </li>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G196\">G196: Using a text alternative on one item within a group of images that describes all items in the group</a>\n               </li>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/html/H2\">H2: Combining adjacent image and text links for the same resource</a>\n               </li>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/html/H37\">H37: Using alt attributes on img elements</a>\n               </li>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/html/H53\">H53: Using the body of the object element</a>\n               </li>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/html/H86\">H86: Providing text alternatives for emojis, emoticons, ASCII art, and leetspeak</a>\n               </li>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/pdf/PDF1\">PDF1: Applying text alternatives to images with the Alt entry in PDF documents</a>\n               </li>\n            </ul>"
+                    "title": "Situation A: If a short description can serve the same purpose and present the same information as the non-text content:",
+                    "techniques": [
+                      {
+                        "id": "G94",
+                        "technology": "general",
+                        "title": "Providing short text alternative for non-text content that serves the same purpose and presents the same information as the non-text content",
+                        "suffix": "using one technique from each group outlined below"
+                      }
+                    ],
+                    "groups": [
+                      {
+                        "id": "text-equiv-all-situation-a-shorttext",
+                        "title": "Short text alternative techniques for Situation A",
+                        "techniques": [
+                          {
+                            "id": "ARIA6",
+                            "technology": "aria",
+                            "title": "Using aria-label to provide labels for objects"
+                          },
+                          {
+                            "id": "ARIA10",
+                            "technology": "aria",
+                            "title": "Using aria-labelledby to provide a text alternative for non-text content"
+                          },
+                          {
+                            "id": "G196",
+                            "technology": "general",
+                            "title": "Using a text alternative on one item within a group of images that describes all items in the group"
+                          },
+                          {
+                            "id": "H2",
+                            "technology": "html",
+                            "title": "Combining adjacent image and text links for the same resource"
+                          },
+                          {
+                            "id": "H37",
+                            "technology": "html",
+                            "title": "Using alt attributes on img elements"
+                          },
+                          {
+                            "id": "H53",
+                            "technology": "html",
+                            "title": "Using the body of the object element"
+                          },
+                          {
+                            "id": "H86",
+                            "technology": "html",
+                            "title": "Providing text alternatives for emojis, emoticons, ASCII art, and leetspeak"
+                          },
+                          {
+                            "id": "PDF1",
+                            "technology": "pdf",
+                            "title": "Applying text alternatives to images with the Alt entry in PDF documents"
+                          }
+                        ]
+                      }
+                    ]
                   },
                   {
-                    "title": "Situation B: If a short description can \n               not serve the same purpose and present the same information as the non-text content (e.g.,\n               a chart or diagram):",
-                    "content": "<ul>\n               <li> \n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G95\">G95: Providing short text alternatives that provide a brief description of the non-text content</a> using one of the following \n                  <strong>\n                     <a href=\"#text-equiv-all-situation-b-shorttext\">Short text alternative techniques for Situation B</a>\n                  </strong>\n                  <strong>AND</strong> one of the following \n                  <strong>\n                     <a href=\"#text-equiv-all-situation-b-longtext\">Long text alternative techniques for Situation B</a>\n                  </strong>:\n               </li>\n            </ul>\n            <p id=\"text-equiv-all-situation-b-shorttext\">\n               <strong>Short text alternative techniques for Situation B</strong>:\n            </p>\n            <ul id=\"text-equiv-all-situation-a-shorttext-techs2\">\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/aria/ARIA6\">ARIA6: Using aria-label to provide labels for objects</a>\n               </li>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/aria/ARIA10\">ARIA10: Using aria-labelledby to provide a text alternative for non-text content</a>\n               </li>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G196\">G196: Using a text alternative on one item within a group of images that describes all items in the group</a>\n               </li>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/html/H2\">H2: Combining adjacent image and text links for the same resource</a>\n               </li>\n               <li>                  \n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/html/H37\">H37: Using alt attributes on img elements</a>\n               </li>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/html/H53\">H53: Using the body of the object element</a>\n               </li>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/html/H86\">H86: Providing text alternatives for emojis, emoticons, ASCII art, and leetspeak</a>\n               </li>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/pdf/PDF1\">PDF1: Applying text alternatives to images with the Alt entry in PDF documents</a>\n               </li>\n            </ul>\n            <p id=\"text-equiv-all-situation-b-longtext\">\n               <strong>Long text alternative techniques for Situation B</strong>:\n            </p>\n            <ul id=\"text-equiv-all-situation-b-longtext-techs\">\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/aria/ARIA15\">ARIA15: Using aria-describedby to provide descriptions of images</a>\n               </li>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G73\">G73: Providing a long description in another location with a link to it that is immediately adjacent to the non-text content</a>\n               </li>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G74\">G74: Providing a long description in text near the non-text content, with a reference to the location of the long description in the short description</a>\n               </li>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G92\">G92: Providing long description for non-text content that serves the same purpose and presents the same information</a>\n               </li>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/html/H53\">H53: Using the body of the object element</a>\n               </li>\n            </ul>"
+                    "title": "Situation B: If a short description can <strong>not</strong> serve the same purpose and present the same information as the non-text content (e.g., a chart or diagram):",
+                    "techniques": [
+                      {
+                        "id": "G95",
+                        "technology": "general",
+                        "title": "Providing short text alternatives that provide a brief description of the non-text content",
+                        "suffix": "using one technique from each group outlined below"
+                      }
+                    ],
+                    "groups": [
+                      {
+                        "id": "text-equiv-all-situation-b-shorttext",
+                        "title": "Short text alternative techniques for Situation B",
+                        "techniques": [
+                          {
+                            "id": "ARIA6",
+                            "technology": "aria",
+                            "title": "Using aria-label to provide labels for objects"
+                          },
+                          {
+                            "id": "ARIA10",
+                            "technology": "aria",
+                            "title": "Using aria-labelledby to provide a text alternative for non-text content"
+                          },
+                          {
+                            "id": "G196",
+                            "technology": "general",
+                            "title": "Using a text alternative on one item within a group of images that describes all items in the group"
+                          },
+                          {
+                            "id": "H2",
+                            "technology": "html",
+                            "title": "Combining adjacent image and text links for the same resource"
+                          },
+                          {
+                            "id": "H37",
+                            "technology": "html",
+                            "title": "Using alt attributes on img elements"
+                          },
+                          {
+                            "id": "H53",
+                            "technology": "html",
+                            "title": "Using the body of the object element"
+                          },
+                          {
+                            "id": "H86",
+                            "technology": "html",
+                            "title": "Providing text alternatives for emojis, emoticons, ASCII art, and leetspeak"
+                          },
+                          {
+                            "id": "PDF1",
+                            "technology": "pdf",
+                            "title": "Applying text alternatives to images with the Alt entry in PDF documents"
+                          }
+                        ]
+                      },
+                      {
+                        "id": "text-equiv-all-situation-b-longtext",
+                        "title": "Long text alternative techniques for Situation B",
+                        "techniques": [
+                          {
+                            "id": "ARIA15",
+                            "technology": "aria",
+                            "title": "Using aria-describedby to provide descriptions of images"
+                          },
+                          {
+                            "id": "G73",
+                            "technology": "general",
+                            "title": "Providing a long description in another location with a link to it that is immediately adjacent to the non-text content"
+                          },
+                          {
+                            "id": "G74",
+                            "technology": "general",
+                            "title": "Providing a long description in text near the non-text content, with a reference to the location of the long description in the short description"
+                          },
+                          {
+                            "id": "G92",
+                            "technology": "general",
+                            "title": "Providing long description for non-text content that serves the same purpose and presents the same information"
+                          },
+                          {
+                            "id": "H53",
+                            "technology": "html",
+                            "title": "Using the body of the object element"
+                          }
+                        ]
+                      }
+                    ]
                   },
                   {
                     "title": "Situation C: If non-text content is a control or accepts user input:",
-                    "content": "<ul>\n               <li> \n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G82\">G82: Providing a text alternative that identifies the purpose of the non-text content</a> using one of the following \n                  <strong>\n                     <a href=\"#text-equiv-all-situation-c-controls\">Text alternative techniques for controls and input for Situation C</a>\n                  </strong>:\n               </li>\n            </ul>\n            <p id=\"text-equiv-all-situation-c-controls\">\n               <strong>Text alternative techniques for controls and input for Situation C</strong>:\n            </p>\n            <ul id=\"text-equiv-all-situation-c-controls-techs\">\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/aria/ARIA6\">ARIA6: Using aria-label to provide labels for objects</a>\n               </li>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/aria/ARIA9\">ARIA9: Using aria-labelledby to concatenate a label from several text nodes</a>\n               </li>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/html/H24\">H24: Providing text alternatives for the area elements of image maps</a>\n               </li>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/html/H30\">H30: Providing link text that describes the purpose of a link for anchor elements</a>\n               </li>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/html/H36\">H36: Using alt attributes on images used as submit buttons</a>\n               </li>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/html/H44\">H44: Using label elements to associate text labels with form controls</a>\n               </li>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/html/H65\">H65: Using the title attribute to identify form controls when the label element cannot be used</a>\n               </li>\n            </ul>"
+                    "techniques": [
+                      {
+                        "id": "G82",
+                        "technology": "general",
+                        "title": "Providing a text alternative that identifies the purpose of the non-text content",
+                        "suffix": "using one technique from each group outlined below"
+                      }
+                    ],
+                    "groups": [
+                      {
+                        "id": "text-equiv-all-situation-c-controls",
+                        "title": "Text alternative techniques for controls and input for Situation C",
+                        "techniques": [
+                          {
+                            "id": "ARIA6",
+                            "technology": "aria",
+                            "title": "Using aria-label to provide labels for objects"
+                          },
+                          {
+                            "id": "ARIA9",
+                            "technology": "aria",
+                            "title": "Using aria-labelledby to concatenate a label from several text nodes"
+                          },
+                          {
+                            "id": "H24",
+                            "technology": "html",
+                            "title": "Providing text alternatives for the area elements of image maps"
+                          },
+                          {
+                            "id": "H30",
+                            "technology": "html",
+                            "title": "Providing link text that describes the purpose of a link for anchor elements"
+                          },
+                          {
+                            "id": "H36",
+                            "technology": "html",
+                            "title": "Using alt attributes on images used as submit buttons"
+                          },
+                          {
+                            "id": "H44",
+                            "technology": "html",
+                            "title": "Using label elements to associate text labels with form controls"
+                          },
+                          {
+                            "id": "H65",
+                            "technology": "html",
+                            "title": "Using the title attribute to identify form controls when the label element cannot be used"
+                          }
+                        ]
+                      }
+                    ]
                   },
                   {
-                    "title": "Situation D: If non-text content is time-based media (including live video-only and\n               live audio-only); a test or exercise that would be invalid if presented in text; or\n               primarily intended to create a specific sensory experience:",
-                    "content": "<ul>\n               <li>Providing a descriptive label using one of the following \n                  <strong>\n                     <a href=\"#text-equiv-all-situation-d-shorttext\">Short text alternative techniques for Situation D</a>\n                  </strong>:\n               </li>\n               <li> \n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G68\">G68: Providing a short text alternative that describes the purpose of live audio-only and live video-only content</a> using one of the following \n                  <strong>\n                     <a href=\"#text-equiv-all-situation-d-shorttext\">Short text alternative techniques for Situation D</a>\n                  </strong>:\n               </li>\n               <li> \n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G100\">G100: Providing a short text alternative which is the accepted name or a descriptive name of the non-text content</a> using one of the following \n                  <strong>\n                     <a href=\"#text-equiv-all-situation-d-shorttext\">Short text alternative techniques for Situation D</a>\n                  </strong>:\n               </li>\n            </ul>\n            <p id=\"text-equiv-all-situation-d-shorttext\">\n               <strong>Short text alternative techniques for Situation D</strong>:\n            </p>\n            <ul id=\"text-equiv-all-situation-a-shorttext-techs3\">\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/aria/ARIA6\">ARIA6: Using aria-label to provide labels for objects</a>\n               </li>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/aria/ARIA10\">ARIA10: Using aria-labelledby to provide a text alternative for non-text content</a>\n               </li>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G196\">G196: Using a text alternative on one item within a group of images that describes all items in the group</a>\n               </li>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/html/H2\">H2: Combining adjacent image and text links for the same resource</a>\n               </li>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/html/H37\">H37: Using alt attributes on img elements</a>\n               </li>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/html/H53\">H53: Using the body of the object element</a>\n               </li>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/html/H86\">H86: Providing text alternatives for emojis, emoticons, ASCII art, and leetspeak</a>\n               </li>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/pdf/PDF1\">PDF1: Applying text alternatives to images with the Alt entry in PDF documents</a>\n               </li>\n            </ul>"
+                    "title": "Situation D: If non-text content is time-based media (including live video-only and live audio-only); a test or exercise that would be invalid if presented in text; or primarily intended to create a specific sensory experience:",
+                    "techniques": [
+                      {
+                        "title": "Providing a descriptive label",
+                        "suffix": "using one technique from each group outlined below"
+                      },
+                      {
+                        "id": "G68",
+                        "technology": "general",
+                        "title": "Providing a short text alternative that describes the purpose of live audio-only and live video-only content",
+                        "suffix": "using one technique from each group outlined below"
+                      },
+                      {
+                        "id": "G100",
+                        "technology": "general",
+                        "title": "Providing a short text alternative which is the accepted name or a descriptive name of the non-text content",
+                        "suffix": "using one technique from each group outlined below"
+                      }
+                    ],
+                    "groups": [
+                      {
+                        "id": "text-equiv-all-situation-d-shorttext",
+                        "title": "Short text alternative techniques for Situation D",
+                        "techniques": [
+                          {
+                            "id": "ARIA6",
+                            "technology": "aria",
+                            "title": "Using aria-label to provide labels for objects"
+                          },
+                          {
+                            "id": "ARIA10",
+                            "technology": "aria",
+                            "title": "Using aria-labelledby to provide a text alternative for non-text content"
+                          },
+                          {
+                            "id": "G196",
+                            "technology": "general",
+                            "title": "Using a text alternative on one item within a group of images that describes all items in the group"
+                          },
+                          {
+                            "id": "H2",
+                            "technology": "html",
+                            "title": "Combining adjacent image and text links for the same resource"
+                          },
+                          {
+                            "id": "H37",
+                            "technology": "html",
+                            "title": "Using alt attributes on img elements"
+                          },
+                          {
+                            "id": "H53",
+                            "technology": "html",
+                            "title": "Using the body of the object element"
+                          },
+                          {
+                            "id": "H86",
+                            "technology": "html",
+                            "title": "Providing text alternatives for emojis, emoticons, ASCII art, and leetspeak"
+                          },
+                          {
+                            "id": "PDF1",
+                            "technology": "pdf",
+                            "title": "Applying text alternatives to images with the Alt entry in PDF documents"
+                          }
+                        ]
+                      }
+                    ]
                   },
                   {
                     "title": "Situation E: If non-text content is a CAPTCHA:",
-                    "content": "<ul>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G143\">G143: Providing a text alternative that describes the purpose of the CAPTCHA</a>\n                  <strong>AND</strong>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G144\">G144: Ensuring that the Web Page contains another CAPTCHA serving the same purpose using a different modality</a>\n               </li>\n            </ul>"
+                    "techniques": [
+                      {
+                        "and": [
+                          {
+                            "id": "G143",
+                            "technology": "general",
+                            "title": "Providing a text alternative that describes the purpose of the CAPTCHA"
+                          },
+                          {
+                            "id": "G144",
+                            "technology": "general",
+                            "title": "Ensuring that the web page contains another CAPTCHA serving the same purpose using a different modality"
+                          }
+                        ]
+                      }
+                    ]
                   },
                   {
                     "title": "Situation F: If the non-text content should be ignored by assistive technology:",
-                    "content": "<ul>\n               <li>Implementing or marking the non-text content so that it will be ignored by assistive\n                  technology using one of the following \n                  <strong>\n                     <a href=\"#text-equiv-all-situation-f-notrequired\">Techniques to indicate that text alternatives are not required for Situation F</a>\n                  </strong>:\n               </li>\n            </ul>\n            <p id=\"text-equiv-all-situation-f-notrequired\">\n               <strong>Techniques to indicate that text alternatives are not required for Situation F</strong>:\n            </p>\n            <ul id=\"text-equiv-all-situation-f-notrequired-techs\">\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/css/C9\">C9: Using CSS to include decorative images</a>\n               </li>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/html/H67\">H67: Using null alt text and no title attribute on img elements for images that assistive technology should ignore</a>\n               </li>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/pdf/PDF4\">PDF4: Hiding decorative images with the Artifact tag in PDF documents</a>\n               </li>\n            </ul>"
+                    "techniques": [
+                      {
+                        "title": "Implementing or marking the non-text content so that it will be ignored by assistive technology",
+                        "suffix": "using one technique from each group outlined below"
+                      }
+                    ],
+                    "groups": [
+                      {
+                        "id": "text-equiv-all-situation-f-notrequired",
+                        "title": "Techniques to indicate that text alternatives are not required for Situation F",
+                        "techniques": [
+                          {
+                            "id": "C9",
+                            "technology": "css",
+                            "title": "Using CSS to include decorative images"
+                          },
+                          {
+                            "id": "H67",
+                            "technology": "html",
+                            "title": "Using null alt text and no title attribute on img elements for images that assistive technology should ignore"
+                          },
+                          {
+                            "id": "PDF4",
+                            "technology": "pdf",
+                            "title": "Hiding decorative images with the Artifact tag in PDF documents"
+                          }
+                        ]
+                      }
+                    ]
                   }
                 ],
-                "advisory": "<ul>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/css/C18\">C18: Using CSS margin and padding rules instead of spacer images for layout design</a>\n               </li>\n            </ul>",
-                "failure": "<ul>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/failures/F3\">F3: Failure of Success Criterion 1.1.1 due to using CSS to include images that convey important information</a>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/failures/F13\">F13: Failure of Success Criterion 1.1.1 and 1.4.1 due to having a text alternative that does not include information that is conveyed by color differences in the image</a>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/failures/F20\">F20: Failure of Success Criterion 1.1.1 and 4.1.2 due to not updating text alternatives when changes to non-text content occur</a>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/failures/F30\">F30: Failure of Success Criterion 1.1.1 and 1.2.1 due to using text alternatives that are not alternatives (e.g., filenames or placeholder text)</a>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/failures/F38\">F38: Failure of Success Criterion 1.1.1 due to not marking up decorative images in HTML in a way that allows assistive technology to ignore them</a>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/failures/F39\">F39: Failure of Success Criterion 1.1.1 due to providing a text alternative that is not null (e.g., alt=\"spacer\" or alt=\"image\") for images that should be ignored by assistive technology</a>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/failures/F65\">F65: Failure of Success Criterion 1.1.1 due to omitting the alt attribute or text alternative on img elements, area elements, and input elements of type \"image\"</a>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/failures/F67\">F67: Failure of Success Criterion 1.1.1 and 1.2.1 due to providing long descriptions for non-text content that does not serve the same purpose or does not present the same information</a>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/failures/F71\">F71: Failure of Success Criterion 1.1.1 due to using text look-alikes to represent text without providing a text alternative</a>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/failures/F72\">F72: Failure of Success Criterion 1.1.1 due to using ASCII art without providing a text alternative</a>\n            </li>\n         </ul>"
+                "advisory": [
+                  {
+                    "id": "C18",
+                    "technology": "css",
+                    "title": "Using CSS margin and padding rules instead of spacer images for layout design"
+                  }
+                ],
+                "failure": [
+                  {
+                    "id": "F3",
+                    "technology": "failures",
+                    "title": "Failure of Success Criterion 1.1.1 due to using CSS to include images that convey important information"
+                  },
+                  {
+                    "id": "F13",
+                    "technology": "failures",
+                    "title": "Failure of Success Criterion 1.1.1 and 1.4.1 due to having a text alternative that does not include information that is conveyed by color differences in the image"
+                  },
+                  {
+                    "id": "F20",
+                    "technology": "failures",
+                    "title": "Failure of Success Criterion 1.1.1 and 4.1.2 due to not updating text alternatives when changes to non-text content occur"
+                  },
+                  {
+                    "id": "F30",
+                    "technology": "failures",
+                    "title": "Failure of Success Criterion 1.1.1 and 1.2.1 due to using text alternatives that are not alternatives (e.g., filenames or placeholder text)"
+                  },
+                  {
+                    "id": "F38",
+                    "technology": "failures",
+                    "title": "Failure of Success Criterion 1.1.1 due to not marking up decorative images in HTML in a way that allows assistive technology to ignore them"
+                  },
+                  {
+                    "id": "F39",
+                    "technology": "failures",
+                    "title": "Failure of Success Criterion 1.1.1 due to providing a text alternative that is not null (e.g., alt=\"spacer\" or alt=\"image\") for images that should be ignored by assistive technology"
+                  },
+                  {
+                    "id": "F65",
+                    "technology": "failures",
+                    "title": "Failure of Success Criterion 1.1.1 due to omitting the alt attribute or text alternative on img elements, area elements, and input elements of type \"image\""
+                  },
+                  {
+                    "id": "F67",
+                    "technology": "failures",
+                    "title": "Failure of Success Criterion 1.1.1 and 1.2.1 due to providing long descriptions for non-text content that does not serve the same purpose or does not present the same information"
+                  },
+                  {
+                    "id": "F71",
+                    "technology": "failures",
+                    "title": "Failure of Success Criterion 1.1.1 due to using text look-alikes to represent text without providing a text alternative"
+                  },
+                  {
+                    "id": "F72",
+                    "technology": "failures",
+                    "title": "Failure of Success Criterion 1.1.1 due to using ASCII art without providing a text alternative"
+                  }
+                ]
               }
             }
           ]
@@ -146,19 +502,53 @@
                   ]
                 }
               ],
-              "techniquesHtml": {
+              "techniques": {
                 "sufficient": [
                   {
                     "title": "Situation A: If the content is prerecorded audio-only:",
-                    "content": "<ul>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G158\">G158: Providing an alternative for time-based media for audio-only content</a>\n               </li>\n            </ul>"
+                    "techniques": [
+                      {
+                        "id": "G158",
+                        "technology": "general",
+                        "title": "Providing an alternative for time-based media for audio-only content"
+                      }
+                    ]
                   },
                   {
                     "title": "Situation B: If the content is prerecorded video-only:",
-                    "content": "<ul>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G159\">G159: Providing an alternative for time-based media for video-only content</a>\n               </li>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G166\">G166: Providing audio that describes the important video content and describing it as such</a>\n               </li>\n            </ul>"
+                    "techniques": [
+                      {
+                        "id": "G159",
+                        "technology": "general",
+                        "title": "Providing an alternative for time-based media for video-only content"
+                      },
+                      {
+                        "id": "G166",
+                        "technology": "general",
+                        "title": "Providing audio that describes the important video content and describing it as such"
+                      }
+                    ]
                   }
                 ],
-                "advisory": "<ul>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/html/H96\">H96: Using the track element to provide audio descriptions</a>\n            </li>\n         </ul>",
-                "failure": "<ul>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/failures/F30\">F30: Failure of Success Criterion 1.1.1 and 1.2.1 due to using text alternatives that are not alternatives (e.g., filenames or placeholder text)</a>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/failures/F67\">F67: Failure of Success Criterion 1.1.1 and 1.2.1 due to providing long descriptions for non-text content that does not serve the same purpose or does not present the same information</a>\n            </li>\n         </ul>"
+                "advisory": [
+                  {
+                    "id": "H96",
+                    "technology": "html",
+                    "title": "Using the track element to provide audio descriptions"
+                  }
+                ],
+                "failure": [
+                  {
+                    "id": "F30",
+                    "technology": "failures",
+                    "title": "Failure of Success Criterion 1.1.1 and 1.2.1 due to using text alternatives that are not alternatives (e.g., filenames or placeholder text)"
+                  },
+                  {
+                    "id": "F67",
+                    "technology": "failures",
+                    "title": "Failure of Success Criterion 1.1.1 and 1.2.1 due to providing long descriptions for non-text content that does not serve the same purpose or does not present the same information"
+                  }
+                ]
               }
             },
             {
@@ -176,9 +566,57 @@
               ],
               "level": "A",
               "details": [],
-              "techniquesHtml": {
-                "sufficient": "<ul>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G93\">G93: Providing open (always visible) captions</a>\n            </li>\n            <li> \n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G87\">G87: Providing closed captions</a> using any readily available media format that has a video player that  supports closed\n               captioning \n            </li>\n            <li>\n               <p> \n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G87\">G87: Providing closed captions</a> using any of the technology-specific techniques below \n               </p>\n               <ul>\n                  <li>\n                     <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/smil/SM11\">SM11: Providing captions through synchronized text streams in SMIL 1.0</a>\n                  </li>\n                  <li>\n                     <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/smil/SM12\">SM12: Providing captions through synchronized text streams in SMIL 2.0</a>\n                  </li>\n                  <li>\n                     <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/html/H95\">H95: Using the track element to provide captions</a>\n                  </li>\n               </ul>\n            </li>\n         </ul>",
-                "failure": "<ul>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/failures/F8\">F8: Failure of Success Criterion 1.2.2 due to captions omitting some dialogue or important sound effects</a>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/failures/F75\">F75: Failure of Success Criterion 1.2.2 by providing synchronized media without captions when the synchronized media presents more information than is presented on the page</a>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/failures/F74\">F74: Failure of  Success Criterion 1.2.2 and 1.2.8 due to not labeling a synchronized media alternative to text as an alternative</a>\n            </li>\n         </ul>"
+              "techniques": {
+                "sufficient": [
+                  {
+                    "id": "G93",
+                    "technology": "general",
+                    "title": "Providing open (always visible) captions"
+                  },
+                  {
+                    "id": "G87",
+                    "technology": "general",
+                    "title": "Providing closed captions",
+                    "suffix": "using any of the following techniques:",
+                    "using": [
+                      {
+                        "id": "SM11",
+                        "technology": "smil",
+                        "title": "Providing captions through synchronized text streams in SMIL 1.0"
+                      },
+                      {
+                        "id": "SM12",
+                        "technology": "smil",
+                        "title": "Providing captions through synchronized text streams in SMIL 2.0"
+                      },
+                      {
+                        "id": "H95",
+                        "technology": "html",
+                        "title": "Using the track element to provide captions"
+                      },
+                      {
+                        "title": "Using any readily available media format that has a video player that supports closed captioning"
+                      }
+                    ]
+                  }
+                ],
+                "failure": [
+                  {
+                    "id": "F8",
+                    "technology": "failures",
+                    "title": "Failure of Success Criterion 1.2.2 due to captions omitting some dialogue or important sound effects"
+                  },
+                  {
+                    "id": "F75",
+                    "technology": "failures",
+                    "title": "Failure of Success Criterion 1.2.2 by providing synchronized media without captions when the synchronized media presents more information than is presented on the page"
+                  },
+                  {
+                    "id": "F74",
+                    "technology": "failures",
+                    "title": "Failure of  Success Criterion 1.2.2 and 1.2.8 due to not labeling a synchronized media alternative to text as an alternative"
+                  }
+                ]
               }
             },
             {
@@ -196,9 +634,97 @@
               ],
               "level": "A",
               "details": [],
-              "techniquesHtml": {
-                "sufficient": "<ul>\n            <li>\n               <p> \n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G69\">G69: Providing an alternative for time based media</a> using one of the following techniques\n               </p>\n               <ul>\n                  <li>\n                     <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G58\">G58: Placing a link to the alternative for time-based media immediately next to the non-text content</a>\n                  </li>\n               </ul>\n            </li>\n            <li>\n               <p>Linking to the alternative for time-based media using one of the following techniques\n               </p>\n               <ul>\n                  <li>\n                     <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/html/H53\">H53: Using the body of the object element</a>\n                  </li>\n               </ul>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G78\">G78: Providing a second, user-selectable, audio track that includes audio descriptions</a>\n            </li>\n            <li>\n               <p> \n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G173\">G173: Providing a version of a movie with audio descriptions</a> using one of the following:\n               </p>\n               <ul>\n                  <li>\n                     <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/smil/SM6\">SM6: Providing audio description in SMIL 1.0</a>\n                  </li>\n                  <li>\n                     <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/smil/SM7\">SM7: Providing audio description in SMIL 2.0</a>\n                  </li>\n                  <li>\n                     <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G226\">G226: Providing audio descriptions by incorporating narration in the soundtrack</a>\n                  </li>\n                  <li>Using any player that supports audio and video</li>\n               </ul>\n            </li>\n            <li>\n               <p> \n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G8\">G8: Providing a movie with extended audio descriptions</a> using one of the following:    \n               </p>\n               <ul>\n                  <li>\n                     <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/smil/SM1\">SM1: Adding extended audio description in SMIL 1.0</a>\n                  </li>\n                  <li>\n                     <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/smil/SM2\">SM2: Adding extended audio description in SMIL 2.0</a>\n                  </li>\n                  <li>Using any player that supports audio and video</li>\n               </ul>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G203\">G203: Using a static text alternative to describe a talking head video</a>\n            </li>\n         </ul>",
-                "advisory": "<ul>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/html/H96\">H96: Using the track element to provide audio descriptions</a>\n            </li>\n         </ul>"
+              "techniques": {
+                "sufficient": [
+                  {
+                    "id": "G69",
+                    "technology": "general",
+                    "title": "Providing an alternative for time based media",
+                    "suffix": "using one of the following techniques:",
+                    "using": [
+                      {
+                        "id": "G58",
+                        "technology": "general",
+                        "title": "Placing a link to the alternative for time-based media immediately next to the non-text content"
+                      }
+                    ]
+                  },
+                  {
+                    "title": "Linking to the alternative for time-based media",
+                    "suffix": "using one of the following techniques:",
+                    "using": [
+                      {
+                        "id": "H53",
+                        "technology": "html",
+                        "title": "Using the body of the object element"
+                      }
+                    ]
+                  },
+                  {
+                    "id": "G78",
+                    "technology": "general",
+                    "title": "Providing a second, user-selectable, audio track that includes audio descriptions"
+                  },
+                  {
+                    "id": "G173",
+                    "technology": "general",
+                    "title": "Providing a version of a movie with audio descriptions",
+                    "suffix": "using one of the following techniques:",
+                    "using": [
+                      {
+                        "id": "SM6",
+                        "technology": "smil",
+                        "title": "Providing audio description in SMIL 1.0"
+                      },
+                      {
+                        "id": "SM7",
+                        "technology": "smil",
+                        "title": "Providing audio description in SMIL 2.0"
+                      },
+                      {
+                        "id": "G226",
+                        "technology": "general",
+                        "title": "Providing audio descriptions by incorporating narration in the soundtrack"
+                      },
+                      {
+                        "title": "Using any player that supports audio and video"
+                      }
+                    ]
+                  },
+                  {
+                    "id": "G8",
+                    "technology": "general",
+                    "title": "Providing a movie with extended audio descriptions",
+                    "suffix": "using one of the following techniques:",
+                    "using": [
+                      {
+                        "id": "SM1",
+                        "technology": "smil",
+                        "title": "Adding extended audio description in SMIL 1.0"
+                      },
+                      {
+                        "id": "SM2",
+                        "technology": "smil",
+                        "title": "Adding extended audio description in SMIL 2.0"
+                      },
+                      {
+                        "title": "Using any player that supports audio and video"
+                      }
+                    ]
+                  },
+                  {
+                    "id": "G203",
+                    "technology": "general",
+                    "title": "Using a static text alternative to describe a talking head video"
+                  }
+                ],
+                "advisory": [
+                  {
+                    "id": "H96",
+                    "technology": "html",
+                    "title": "Using the track element to provide audio descriptions"
+                  }
+                ]
               }
             },
             {
@@ -216,8 +742,53 @@
               ],
               "level": "AA",
               "details": [],
-              "techniquesHtml": {
-                "sufficient": "<ul>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G9\">G9: Creating captions for live synchronized media</a>\n               <strong>AND</strong>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G93\">G93: Providing open (always visible) captions</a>\n            </li>\n            <li> \n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G9\">G9: Creating captions for live synchronized media</a> \n               <strong>AND</strong> \n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G87\">G87: Providing closed captions</a> using any readily available media format that has a video player that  supports closed\n               captioning \n            </li>\n            <li>\n               <p> \n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G9\">G9: Creating captions for live synchronized media</a> \n                  <strong>AND</strong> \n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G87\">G87: Providing closed captions</a> using one of the following techniques:\n               </p>\n               <ul>\n                  <li>\n                     <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/smil/SM11\">SM11: Providing captions through synchronized text streams in SMIL 1.0</a>\n                  </li>\n                  <li>\n                     <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/smil/SM12\">SM12: Providing captions through synchronized text streams in SMIL 2.0</a>\n                  </li>\n               </ul>\n            </li>\n         </ul>\n         <p class=\"note\">\n\t\t\t\t<em>Note:</em>\n            Captions may be generated using real-time text translation service. \n\t\t\t</p>"
+              "techniques": {
+                "sufficient": [
+                  {
+                    "and": [
+                      {
+                        "id": "G9",
+                        "technology": "general",
+                        "title": "Creating captions for live synchronized media"
+                      },
+                      {
+                        "id": "G93",
+                        "technology": "general",
+                        "title": "Providing open (always visible) captions"
+                      }
+                    ]
+                  },
+                  {
+                    "and": [
+                      {
+                        "id": "G9",
+                        "technology": "general",
+                        "title": "Creating captions for live synchronized media"
+                      },
+                      {
+                        "id": "G87",
+                        "technology": "general",
+                        "title": "Providing closed captions"
+                      }
+                    ],
+                    "using": [
+                      {
+                        "id": "SM11",
+                        "technology": "smil",
+                        "title": "Providing captions through synchronized text streams in SMIL 1.0"
+                      },
+                      {
+                        "id": "SM12",
+                        "technology": "smil",
+                        "title": "Providing captions through synchronized text streams in SMIL 2.0"
+                      },
+                      {
+                        "title": "Using any readily available media format that has a video player that supports closed captioning"
+                      }
+                    ]
+                  }
+                ],
+                "sufficientNote": "Captions may be generated using real-time text translation service."
               }
             },
             {
@@ -235,9 +806,80 @@
               ],
               "level": "AA",
               "details": [],
-              "techniquesHtml": {
-                "sufficient": "<ul>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G78\">G78: Providing a second, user-selectable, audio track that includes audio descriptions</a>\n            </li>\n            <li>\n               <p> \n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G173\">G173: Providing a version of a movie with audio descriptions</a> using one of the following:\n               </p>\n               <ul>\n                  <li>\n                     <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/smil/SM6\">SM6: Providing audio description in SMIL 1.0</a>\n                  </li>\n                  <li>\n                     <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/smil/SM7\">SM7: Providing audio description in SMIL 2.0</a>\n                  </li>\n                  <li>\n                     <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G226\">G226: Providing audio descriptions by incorporating narration in the soundtrack</a>\n                  </li>   \n                  <li>Using any player that supports audio and video</li>\n               </ul>\n            </li>\n            <li>\n               <p> \n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G8\">G8: Providing a movie with extended audio descriptions</a> using one of the following:    \n               </p>\n               <ul>\n                  <li>\n                     <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/smil/SM1\">SM1: Adding extended audio description in SMIL 1.0</a>\n                  </li>\n                  <li>\n                     <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/smil/SM2\">SM2: Adding extended audio description in SMIL 2.0</a>\n                  </li>\n                  <li>Using any player that supports audio and video</li>\n               </ul>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G203\">G203: Using a static text alternative to describe a talking head video</a>\n            </li>\n         </ul>",
-                "advisory": "<ul>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/html/H96\">H96: Using the track element to provide audio descriptions</a>\n            </li>\n         </ul>"
+              "techniques": {
+                "sufficient": [
+                  {
+                    "id": "G78",
+                    "technology": "general",
+                    "title": "Providing a second, user-selectable, audio track that includes audio descriptions"
+                  },
+                  {
+                    "id": "G173",
+                    "technology": "general",
+                    "title": "Providing a version of a movie with audio descriptions",
+                    "suffix": "using one of the following techniques:",
+                    "using": [
+                      {
+                        "id": "SM6",
+                        "technology": "smil",
+                        "title": "Providing audio description in SMIL 1.0"
+                      },
+                      {
+                        "id": "SM7",
+                        "technology": "smil",
+                        "title": "Providing audio description in SMIL 2.0"
+                      },
+                      {
+                        "id": "G226",
+                        "technology": "general",
+                        "title": "Providing audio descriptions by incorporating narration in the soundtrack"
+                      },
+                      {
+                        "title": "Using any player that supports audio and video"
+                      }
+                    ]
+                  },
+                  {
+                    "id": "G8",
+                    "technology": "general",
+                    "title": "Providing a movie with extended audio descriptions",
+                    "suffix": "using one of the following techniques:",
+                    "using": [
+                      {
+                        "id": "SM1",
+                        "technology": "smil",
+                        "title": "Adding extended audio description in SMIL 1.0"
+                      },
+                      {
+                        "id": "SM2",
+                        "technology": "smil",
+                        "title": "Adding extended audio description in SMIL 2.0"
+                      },
+                      {
+                        "title": "Using any player that supports audio and video"
+                      }
+                    ]
+                  },
+                  {
+                    "id": "G203",
+                    "technology": "general",
+                    "title": "Using a static text alternative to describe a talking head video"
+                  }
+                ],
+                "advisory": [
+                  {
+                    "id": "H96",
+                    "technology": "html",
+                    "title": "Using the track element to provide audio descriptions"
+                  }
+                ],
+                "failure": [
+                  {
+                    "id": "F113",
+                    "technology": "failures",
+                    "title": "Failure of Success Criterion 1.2.5 due to not using available pauses in dialogue to provide audio descriptions of important visual content"
+                  }
+                ]
               }
             },
             {
@@ -255,8 +897,32 @@
               ],
               "level": "AAA",
               "details": [],
-              "techniquesHtml": {
-                "sufficient": "<ul>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G54\">G54: Including a sign language interpreter in the video stream</a>\n            </li>\n            <li>\n               <p> \n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G81\">G81: Providing a synchronized video of the sign language interpreter that can be displayed in a different viewport or overlaid on the image by the player</a> using one of the following techniques\n               </p>\n               <ul>\n                  <li>\n                     <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/smil/SM13\">SM13: Providing sign language interpretation through synchronized video streams in SMIL 1.0</a>\n                  </li>\n                  <li>\n                     <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/smil/SM14\">SM14: Providing sign language interpretation through synchronized video streams in SMIL 2.0</a>\n                  </li>\n               </ul>\n            </li>\n         </ul>"
+              "techniques": {
+                "sufficient": [
+                  {
+                    "id": "G54",
+                    "technology": "general",
+                    "title": "Including a sign language interpreter in the video stream"
+                  },
+                  {
+                    "id": "G81",
+                    "technology": "general",
+                    "title": "Providing a synchronized video of the sign language interpreter that can be displayed in a different viewport or overlaid on the image by the player",
+                    "suffix": "using one of the following techniques:",
+                    "using": [
+                      {
+                        "id": "SM13",
+                        "technology": "smil",
+                        "title": "Providing sign language interpretation through synchronized video streams in SMIL 1.0"
+                      },
+                      {
+                        "id": "SM14",
+                        "technology": "smil",
+                        "title": "Providing sign language interpretation through synchronized video streams in SMIL 2.0"
+                      }
+                    ]
+                  }
+                ]
               }
             },
             {
@@ -274,9 +940,37 @@
               ],
               "level": "AAA",
               "details": [],
-              "techniquesHtml": {
-                "sufficient": "<ul>\n            <li>\n               <p> \n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G8\">G8: Providing a movie with extended audio descriptions</a> using one of the following:    \n               </p>\n               <ul>\n                  <li>\n                     <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/smil/SM1\">SM1: Adding extended audio description in SMIL 1.0</a>\n                  </li>\n                  <li>\n                     <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/smil/SM2\">SM2: Adding extended audio description in SMIL 2.0</a>\n                  </li>\n                  <li>Using any player that supports audio and video</li>\n               </ul>\n            </li>\n         </ul>",
-                "advisory": "<ul>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/html/H96\">H96: Using the track element to provide audio descriptions</a>\n            </li>\n         </ul>"
+              "techniques": {
+                "sufficient": [
+                  {
+                    "id": "G8",
+                    "technology": "general",
+                    "title": "Providing a movie with extended audio descriptions",
+                    "suffix": "using one of the following techniques:",
+                    "using": [
+                      {
+                        "id": "SM1",
+                        "technology": "smil",
+                        "title": "Adding extended audio description in SMIL 1.0"
+                      },
+                      {
+                        "id": "SM2",
+                        "technology": "smil",
+                        "title": "Adding extended audio description in SMIL 2.0"
+                      },
+                      {
+                        "title": "Using any player that supports audio and video"
+                      }
+                    ]
+                  }
+                ],
+                "advisory": [
+                  {
+                    "id": "H96",
+                    "technology": "html",
+                    "title": "Using the track element to provide audio descriptions"
+                  }
+                ]
               }
             },
             {
@@ -294,18 +988,55 @@
               ],
               "level": "AAA",
               "details": [],
-              "techniquesHtml": {
+              "techniques": {
                 "sufficient": [
                   {
                     "title": "Situation A: If the content is prerecorded synchronized media:",
-                    "content": "<ul>\n               <li>\n                  <p> \n                     <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G69\">G69: Providing an alternative for time based media</a> using one of the following techniques\n                  </p>\n                  <ul>\n                     <li>\n                        <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G58\">G58: Placing a link to the alternative for time-based media immediately next to the non-text content</a>\n                     </li>\n                  </ul>\n               </li>\n               <li>\n                  <p>Linking to the alternative for time-based media using one of the following techniques\n                  </p>\n                  <ul>\n                     <li>\n                        <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/html/H53\">H53: Using the body of the object element</a>\n                     </li>\n                  </ul>\n               </li>\n            </ul>"
+                    "techniques": [
+                      {
+                        "id": "G69",
+                        "technology": "general",
+                        "title": "Providing an alternative for time based media",
+                        "suffix": "using one of the following techniques:",
+                        "using": [
+                          {
+                            "id": "G58",
+                            "technology": "general",
+                            "title": "Placing a link to the alternative for time-based media immediately next to the non-text content"
+                          }
+                        ]
+                      },
+                      {
+                        "title": "Linking to the alternative for time-based media",
+                        "suffix": "using one of the following techniques:",
+                        "using": [
+                          {
+                            "id": "H53",
+                            "technology": "html",
+                            "title": "Using the body of the object element"
+                          }
+                        ]
+                      }
+                    ]
                   },
                   {
                     "title": "Situation B: If the content is prerecorded video-only:",
-                    "content": "<ul>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G159\">G159: Providing an alternative for time-based media for video-only content</a>\n               </li>\n            </ul>"
+                    "techniques": [
+                      {
+                        "id": "G159",
+                        "technology": "general",
+                        "title": "Providing an alternative for time-based media for video-only content"
+                      }
+                    ]
                   }
                 ],
-                "failure": "<ul>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/failures/F74\">F74: Failure of  Success Criterion 1.2.2 and 1.2.8 due to not labeling a synchronized media alternative to text as an alternative</a>\n            </li>\n         </ul>"
+                "failure": [
+                  {
+                    "id": "F74",
+                    "technology": "failures",
+                    "title": "Failure of  Success Criterion 1.2.2 and 1.2.8 due to not labeling a synchronized media alternative to text as an alternative"
+                  }
+                ]
               }
             },
             {
@@ -323,8 +1054,24 @@
               ],
               "level": "AAA",
               "details": [],
-              "techniquesHtml": {
-                "sufficient": "<ul>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G151\">G151: Providing a link to a text transcript of a prepared statement or script if the script is followed</a>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G150\">G150: Providing text based alternatives for live audio-only content</a>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G157\">G157: Incorporating a live audio captioning service into a web page</a>\n            </li>\n         </ul>"
+              "techniques": {
+                "sufficient": [
+                  {
+                    "id": "G151",
+                    "technology": "general",
+                    "title": "Providing a link to a text transcript of a prepared statement or script if the script is followed"
+                  },
+                  {
+                    "id": "G150",
+                    "technology": "general",
+                    "title": "Providing text based alternatives for live audio-only content"
+                  },
+                  {
+                    "id": "G157",
+                    "technology": "general",
+                    "title": "Incorporating a live audio captioning service into a web page"
+                  }
+                ]
               }
             }
           ]
@@ -358,19 +1105,299 @@
               ],
               "level": "A",
               "details": [],
-              "techniquesHtml": {
+              "techniques": {
                 "sufficient": [
                   {
-                    "title": "Situation A: The technology provides semantic structure to make information and relationships\n               conveyed through presentation programmatically determinable:",
-                    "content": "<ul>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/aria/ARIA11\">ARIA11: Using ARIA landmarks to identify regions of a page</a>\n               </li>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/html/H101\">H101: Using semantic HTML elements to identify regions of a page</a>\n               </li>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/aria/ARIA12\">ARIA12: Using role=heading to identify headings</a>\n               </li>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/aria/ARIA13\">ARIA13: Using aria-labelledby to name regions and landmarks</a>\n               </li>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/aria/ARIA16\">ARIA16: Using aria-labelledby to provide a name for user interface controls</a>\n               </li>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/aria/ARIA17\">ARIA17: Using grouping roles to identify related form controls</a>\n               </li>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/aria/ARIA20\">ARIA20: Using the region role to identify a region of the page</a>\n               </li>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G115\">G115: Using semantic elements to mark up structure</a>\n                  <strong>AND</strong>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/html/H49\">H49: Using semantic markup to mark emphasized or special text</a>\n               </li>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G117\">G117: Using text to convey information that is conveyed by variations in presentation of text</a>\n               </li>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G140\">G140: Separating information and structure from presentation to enable different presentations</a>\n               </li>\n               <li>\n                     <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/aria/ARIA24\">ARIA24: Semantically identifying a font icon with role=\"img\"</a>\n               </li>\n               <li>\n                  <p>Making information and relationships conveyed through presentation programmatically\n                     determinable using the following techniques:\n                  </p>\n                  <ul>\n                     <li>\n                        <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G138\">G138: Using semantic markup whenever color cues are used</a>\n                     </li>\n                     <li>\n                        <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/html/H51\">H51: Using table markup to present tabular information</a>\n                     </li>\n                     <li>\n                        <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/pdf/PDF6\">PDF6: Using table elements for table markup in PDF Documents</a>\n                     </li>\n                     <li>\n                        <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/pdf/PDF20\">PDF20: Using Adobe Acrobat Pro's Table Editor to repair mistagged tables</a>\n                     </li>\n                     <li>\n                        <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/html/H39\">H39: Using caption elements to associate data table captions with data tables</a>\n                     </li>\n                     <li>\n                        <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/html/H63\">H63: Using the scope attribute to associate header cells with data cells in data tables</a>\n                     </li>\n                     <li>\n                        <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/html/H43\">H43: Using id and headers attributes to associate data cells with header cells in data tables</a>\n                     </li>\n                     <li>\n                        <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/html/H44\">H44: Using label elements to associate text labels with form controls</a>\n                     </li>\n                     <li>\n                        <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/html/H65\">H65: Using the title attribute to identify form controls when the label element cannot be used</a>\n                     </li>\n                     <li>\n                        <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/pdf/PDF10\">PDF10: Providing labels for interactive form controls in PDF documents</a>\n                     </li>\n                     <li>\n                        <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/pdf/PDF12\">PDF12: Providing name, role, value information for form fields in PDF documents</a>\n                     </li>\n                     <li>\n                        <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/html/H71\">H71: Providing a description for groups of form controls using fieldset and legend elements</a>\n                     </li>\n                     <li>\n                        <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/html/H85\">H85: Using optgroup to group option elements inside a select</a>\n                     </li>\n                     <li>\n                        <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/html/H48\">H48: Using ol, ul and dl for lists or groups of links</a>\n                     </li>\n                     <li>\n                        <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/html/H42\">H42: Using h1-h6 to identify headings</a>\n                     </li>\n                     <li>\n                        <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/pdf/PDF9\">PDF9: Providing headings by marking content with heading tags in PDF documents</a>\n                     </li>\n                     <li>\n                        <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/pdf/PDF11\">PDF11: Providing links and link text using the Link annotation and the /Link structure element in PDF documents</a>\n                     </li>\n                     <li>\n                        <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/pdf/PDF17\">PDF17: Specifying consistent page numbering for PDF documents</a>\n                     </li>\n                     <li>\n                        <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/pdf/PDF21\">PDF21: Using List tags for lists in PDF documents</a>\n                     </li>\n                     <li>\n                        <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/html/H97\">H97: Grouping related links using the nav element</a>\n                     </li>\n                  </ul>\n               </li>\n            </ul>"
+                    "title": "Situation A: The technology provides semantic structure to make information and relationships conveyed through presentation programmatically determinable:",
+                    "techniques": [
+                      {
+                        "id": "ARIA11",
+                        "technology": "aria",
+                        "title": "Using ARIA landmarks to identify regions of a page"
+                      },
+                      {
+                        "id": "H101",
+                        "technology": "html",
+                        "title": "Using semantic HTML elements to identify regions of a page"
+                      },
+                      {
+                        "id": "ARIA12",
+                        "technology": "aria",
+                        "title": "Using role=heading to identify headings"
+                      },
+                      {
+                        "id": "ARIA13",
+                        "technology": "aria",
+                        "title": "Using aria-labelledby to name regions and landmarks"
+                      },
+                      {
+                        "id": "ARIA16",
+                        "technology": "aria",
+                        "title": "Using aria-labelledby to provide a name for user interface controls"
+                      },
+                      {
+                        "id": "ARIA17",
+                        "technology": "aria",
+                        "title": "Using grouping roles to identify related form controls"
+                      },
+                      {
+                        "id": "ARIA20",
+                        "technology": "aria",
+                        "title": "Using the region role to identify a region of the page"
+                      },
+                      {
+                        "and": [
+                          {
+                            "id": "G115",
+                            "technology": "general",
+                            "title": "Using semantic elements to mark up structure"
+                          },
+                          {
+                            "id": "H49",
+                            "technology": "html",
+                            "title": "Using semantic markup to mark emphasized or special text"
+                          }
+                        ]
+                      },
+                      {
+                        "id": "G117",
+                        "technology": "general",
+                        "title": "Using text to convey information that is conveyed by variations in presentation of text"
+                      },
+                      {
+                        "id": "G140",
+                        "technology": "general",
+                        "title": "Separating information and structure from presentation to enable different presentations"
+                      },
+                      {
+                        "id": "ARIA24",
+                        "technology": "aria",
+                        "title": "Semantically identifying a font icon with role=\"img\""
+                      },
+                      {
+                        "title": "Making information and relationships conveyed through presentation programmatically determinable",
+                        "suffix": "using the following techniques:",
+                        "using": [
+                          {
+                            "id": "G138",
+                            "technology": "general",
+                            "title": "Using semantic markup whenever color cues are used"
+                          },
+                          {
+                            "id": "H51",
+                            "technology": "html",
+                            "title": "Using table markup to present tabular information"
+                          },
+                          {
+                            "id": "PDF6",
+                            "technology": "pdf",
+                            "title": "Using table elements for table markup in PDF Documents"
+                          },
+                          {
+                            "id": "PDF20",
+                            "technology": "pdf",
+                            "title": "Using Adobe Acrobat Pro's Table Editor to repair mistagged tables"
+                          },
+                          {
+                            "id": "H39",
+                            "technology": "html",
+                            "title": "Using caption elements to associate data table captions with data tables"
+                          },
+                          {
+                            "id": "H63",
+                            "technology": "html",
+                            "title": "Using the scope attribute to associate header cells with data cells in data tables"
+                          },
+                          {
+                            "id": "H43",
+                            "technology": "html",
+                            "title": "Using id and headers attributes to associate data cells with header cells in data tables"
+                          },
+                          {
+                            "id": "H44",
+                            "technology": "html",
+                            "title": "Using label elements to associate text labels with form controls"
+                          },
+                          {
+                            "id": "H65",
+                            "technology": "html",
+                            "title": "Using the title attribute to identify form controls when the label element cannot be used"
+                          },
+                          {
+                            "id": "PDF10",
+                            "technology": "pdf",
+                            "title": "Providing labels for interactive form controls in PDF documents"
+                          },
+                          {
+                            "id": "PDF12",
+                            "technology": "pdf",
+                            "title": "Providing name, role, value information for form fields in PDF documents"
+                          },
+                          {
+                            "id": "H71",
+                            "technology": "html",
+                            "title": "Providing a description for groups of form controls using fieldset and legend elements"
+                          },
+                          {
+                            "id": "H85",
+                            "technology": "html",
+                            "title": "Using optgroup to group option elements inside a select"
+                          },
+                          {
+                            "id": "H48",
+                            "technology": "html",
+                            "title": "Using ol, ul and dl for lists or groups of links"
+                          },
+                          {
+                            "id": "H42",
+                            "technology": "html",
+                            "title": "Using h1-h6 to identify headings"
+                          },
+                          {
+                            "id": "PDF9",
+                            "technology": "pdf",
+                            "title": "Providing headings by marking content with heading tags in PDF documents"
+                          },
+                          {
+                            "id": "PDF11",
+                            "technology": "pdf",
+                            "title": "Providing links and link text using the Link annotation and the /Link structure element in PDF documents"
+                          },
+                          {
+                            "id": "PDF17",
+                            "technology": "pdf",
+                            "title": "Specifying consistent page numbering for PDF documents"
+                          },
+                          {
+                            "id": "PDF21",
+                            "technology": "pdf",
+                            "title": "Using List tags for lists in PDF documents"
+                          },
+                          {
+                            "id": "H97",
+                            "technology": "html",
+                            "title": "Grouping related links using the nav element"
+                          }
+                        ]
+                      }
+                    ]
                   },
                   {
-                    "title": "Situation B: The technology in use does NOT provide the semantic structure to make\n               the information and relationships conveyed through presentation programmatically determinable:",
-                    "content": "<ul>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G117\">G117: Using text to convey information that is conveyed by variations in presentation of text</a>\n               </li>\n               <li>\n                  <p>Making information and relationships conveyed through presentation programmatically\n                     determinable or available in text using the following techniques:\n                  </p>\n                  <ul>\n                     <li>\n                        <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/text/T1\">T1: Using standard text formatting conventions for paragraphs</a>\n                     </li>\n                     <li>\n                        <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/text/T2\">T2: Using standard text formatting conventions for lists</a>\n                     </li>\n                     <li>\n                        <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/text/T3\">T3: Using standard text formatting conventions for headings</a>\n                     </li>\n                  </ul>\n               </li>\n            </ul>"
+                    "title": "Situation B: The technology in use does NOT provide the semantic structure to make the information and relationships conveyed through presentation programmatically determinable:",
+                    "techniques": [
+                      {
+                        "id": "G117",
+                        "technology": "general",
+                        "title": "Using text to convey information that is conveyed by variations in presentation of text"
+                      },
+                      {
+                        "title": "Making information and relationships conveyed through presentation programmatically determinable or available in text",
+                        "suffix": "using the following techniques:",
+                        "using": [
+                          {
+                            "id": "T1",
+                            "technology": "text",
+                            "title": "Using standard text formatting conventions for paragraphs"
+                          },
+                          {
+                            "id": "T2",
+                            "technology": "text",
+                            "title": "Using standard text formatting conventions for lists"
+                          },
+                          {
+                            "id": "T3",
+                            "technology": "text",
+                            "title": "Using standard text formatting conventions for headings"
+                          }
+                        ]
+                      }
+                    ]
                   }
                 ],
-                "advisory": "<ul>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/css/C22\">C22: Using CSS to control visual presentation of text</a>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G162\">G162: Positioning labels to maximize predictability of relationships</a>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/aria/ARIA1\">ARIA1: Using the aria-describedby property to provide a descriptive label for user interface controls</a>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/aria/ARIA2\">ARIA2: Identifying a required field with the aria-required property</a>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G141\">G141: Organizing a page using headings</a>\n            </li>\n         </ul>",
-                "failure": "<ul>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/failures/F2\">F2: Failure of Success Criterion 1.3.1 due to using changes in text presentation to convey information without using the appropriate markup or text</a>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/failures/F33\">F33: Failure of Success Criterion 1.3.1 and 1.3.2 due to using white space characters to create multiple columns in plain text content</a>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/failures/F34\">F34: Failure of Success Criterion 1.3.1 and 1.3.2 due to using white space characters to format tables in plain text content</a>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/failures/F42\">F42: Failure of Success Criteria 1.3.1, 2.1.1, 2.1.3, or 4.1.2 when emulating links</a>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/failures/F43\">F43: Failure of Success Criterion 1.3.1 due to using structural markup in a way that does not represent relationships in the content</a>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/failures/F46\">F46: Failure of Success Criterion 1.3.1 due to using th elements, caption elements, or non-empty summary attributes in layout tables</a>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/failures/F48\">F48: Failure of Success Criterion 1.3.1 due to using the pre element to markup tabular information</a>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/failures/F90\">F90: Failure of Success Criterion 1.3.1 for incorrectly associating table headers and content via the headers and id attributes</a>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/failures/F91\">F91: Failure of Success Criterion 1.3.1 for not correctly marking up table headers</a>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/failures/F92\">F92: Failure of Success Criterion 1.3.1 due to the use of role presentation on content which conveys semantic information</a>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/failures/F111\">F111: Failure of Success Criteria 1.3.1, 2.5.3, and 4.1.2 due to a control with visible label text but no accessible name</a>\n            </li>\n         </ul>"
+                "advisory": [
+                  {
+                    "id": "C22",
+                    "technology": "css",
+                    "title": "Using CSS to control visual presentation of text"
+                  },
+                  {
+                    "id": "G162",
+                    "technology": "general",
+                    "title": "Positioning labels to maximize predictability of relationships"
+                  },
+                  {
+                    "id": "ARIA1",
+                    "technology": "aria",
+                    "title": "Using the aria-describedby property to provide a descriptive label for user interface controls"
+                  },
+                  {
+                    "id": "ARIA2",
+                    "technology": "aria",
+                    "title": "Identifying a required field with the aria-required property"
+                  },
+                  {
+                    "id": "G141",
+                    "technology": "general",
+                    "title": "Organizing a page using headings"
+                  }
+                ],
+                "failure": [
+                  {
+                    "id": "F2",
+                    "technology": "failures",
+                    "title": "Failure of Success Criterion 1.3.1 due to using changes in text presentation to convey information without using the appropriate markup or text"
+                  },
+                  {
+                    "id": "F33",
+                    "technology": "failures",
+                    "title": "Failure of Success Criterion 1.3.1 and 1.3.2 due to using white space characters to create multiple columns in plain text content"
+                  },
+                  {
+                    "id": "F34",
+                    "technology": "failures",
+                    "title": "Failure of Success Criterion 1.3.1 and 1.3.2 due to using white space characters to format tables in plain text content"
+                  },
+                  {
+                    "id": "F42",
+                    "technology": "failures",
+                    "title": "Failure of Success Criteria 1.3.1, 2.1.1, 2.1.3, or 4.1.2 when emulating links"
+                  },
+                  {
+                    "id": "F43",
+                    "technology": "failures",
+                    "title": "Failure of Success Criterion 1.3.1 due to using structural markup in a way that does not represent relationships in the content"
+                  },
+                  {
+                    "id": "F46",
+                    "technology": "failures",
+                    "title": "Failure of Success Criterion 1.3.1 due to using th elements, caption elements, or non-empty summary attributes in layout tables"
+                  },
+                  {
+                    "id": "F48",
+                    "technology": "failures",
+                    "title": "Failure of Success Criterion 1.3.1 due to using the pre element to markup tabular information"
+                  },
+                  {
+                    "id": "F90",
+                    "technology": "failures",
+                    "title": "Failure of Success Criterion 1.3.1 for incorrectly associating table headers and content via the headers and id attributes"
+                  },
+                  {
+                    "id": "F91",
+                    "technology": "failures",
+                    "title": "Failure of Success Criterion 1.3.1 for not correctly marking up table headers"
+                  },
+                  {
+                    "id": "F92",
+                    "technology": "failures",
+                    "title": "Failure of Success Criterion 1.3.1 due to the use of role presentation on content which conveys semantic information"
+                  },
+                  {
+                    "id": "F111",
+                    "technology": "failures",
+                    "title": "Failure of Success Criteria 1.3.1, 2.5.3, and 4.1.2 due to a control with visible label text but no accessible name"
+                  }
+                ]
               }
             },
             {
@@ -388,9 +1415,81 @@
               ],
               "level": "A",
               "details": [],
-              "techniquesHtml": {
-                "sufficient": "<ul>\n            <li> \n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G57\">G57: Ordering the content in a meaningful sequence</a> for all the content in the web page\n            </li>\n            <li>\n               <p>Marking sequences in the content as meaningful using one of the following techniques\n                  <strong>AND</strong> \n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G57\">G57: Ordering the content in a meaningful sequence</a> for those sequences    \n               </p>\n               <ul>\n                  <li>\n                     <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/html/H34\">H34: Using a Unicode right-to-left mark (RLM) or left-to-right mark (LRM) to mix text direction inline</a>\n                  </li>\n                  <li>\n                     <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/html/H56\">H56: Using the dir attribute on an inline element to resolve problems with nested directional runs</a>\n                  </li>\n                  <li>\n                     <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/css/C6\">C6: Positioning content based on structural markup</a>\n                  </li>\n                  <li>\n                     <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/css/C8\">C8: Using CSS letter-spacing to control spacing within a word</a>\n                  </li>\n               </ul>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/css/C27\">C27: Making the DOM order match the visual order</a>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/pdf/PDF3\">PDF3: Ensuring correct tab and reading order in PDF documents</a>\n            </li>\n         </ul>",
-                "failure": "<ul>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/failures/F34\">F34: Failure of Success Criterion 1.3.1 and 1.3.2 due to using white space characters to format tables in plain text content</a>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/failures/F33\">F33: Failure of Success Criterion 1.3.1 and 1.3.2 due to using white space characters to create multiple columns in plain text content</a>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/failures/F32\">F32: Failure of Success Criterion 1.3.2 due to using white space characters to control spacing within a word</a>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/failures/F49\">F49:  Failure of Success Criterion 1.3.2 due to using an HTML layout table that does not make sense when linearized  </a>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/failures/F1\">F1: Failure of Success Criterion 1.3.2 due to changing the meaning of content by positioning information with CSS</a>\n            </li>\n         </ul>"
+              "techniques": {
+                "sufficient": [
+                  {
+                    "id": "G57",
+                    "technology": "general",
+                    "title": "Ordering the content in a meaningful sequence",
+                    "suffix": "for all the content in the web page"
+                  },
+                  {
+                    "id": "G57",
+                    "technology": "general",
+                    "title": "Ordering the content in a meaningful sequence",
+                    "prefix": "Marking sequences in the content as meaningful using one of the following techniques <strong>AND</strong>",
+                    "suffix": "for those sequences",
+                    "using": [
+                      {
+                        "id": "H34",
+                        "technology": "html",
+                        "title": "Using a Unicode right-to-left mark (RLM) or left-to-right mark (LRM) to mix text direction inline"
+                      },
+                      {
+                        "id": "H56",
+                        "technology": "html",
+                        "title": "Using the dir attribute on an inline element to resolve problems with nested directional runs"
+                      },
+                      {
+                        "id": "C6",
+                        "technology": "css",
+                        "title": "Positioning content based on structural markup"
+                      },
+                      {
+                        "id": "C8",
+                        "technology": "css",
+                        "title": "Using CSS letter-spacing to control spacing within a word"
+                      }
+                    ]
+                  },
+                  {
+                    "id": "C27",
+                    "technology": "css",
+                    "title": "Making the DOM order match the visual order"
+                  },
+                  {
+                    "id": "PDF3",
+                    "technology": "pdf",
+                    "title": "Ensuring correct tab and reading order in PDF documents"
+                  }
+                ],
+                "failure": [
+                  {
+                    "id": "F34",
+                    "technology": "failures",
+                    "title": "Failure of Success Criterion 1.3.1 and 1.3.2 due to using white space characters to format tables in plain text content"
+                  },
+                  {
+                    "id": "F33",
+                    "technology": "failures",
+                    "title": "Failure of Success Criterion 1.3.1 and 1.3.2 due to using white space characters to create multiple columns in plain text content"
+                  },
+                  {
+                    "id": "F32",
+                    "technology": "failures",
+                    "title": "Failure of Success Criterion 1.3.2 due to using white space characters to control spacing within a word"
+                  },
+                  {
+                    "id": "F49",
+                    "technology": "failures",
+                    "title": "Failure of Success Criterion 1.3.2 due to using an HTML layout table that does not make sense when linearized"
+                  },
+                  {
+                    "id": "F1",
+                    "technology": "failures",
+                    "title": "Failure of Success Criterion 1.3.2 due to changing the meaning of content by positioning information with CSS"
+                  }
+                ]
               }
             },
             {
@@ -414,9 +1513,26 @@
                   "text": "For requirements related to color, refer to Guideline 1.4."
                 }
               ],
-              "techniquesHtml": {
-                "sufficient": "<ul>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G96\">G96: Providing textual identification of items that otherwise rely only on sensory information to be understood</a>\n            </li>\n         </ul>",
-                "failure": "<ul>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/failures/F14\">F14: Failure of Success Criterion 1.3.3 due to identifying content only by its shape or location</a>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/failures/F26\">F26:  Failure of Success Criterion 1.3.3 due to using a graphical symbol alone to convey information</a>\n            </li>\n         </ul>"
+              "techniques": {
+                "sufficient": [
+                  {
+                    "id": "G96",
+                    "technology": "general",
+                    "title": "Providing textual identification of items that otherwise rely only on sensory information to be understood"
+                  }
+                ],
+                "failure": [
+                  {
+                    "id": "F14",
+                    "technology": "failures",
+                    "title": "Failure of Success Criterion 1.3.3 due to identifying content only by its shape or location"
+                  },
+                  {
+                    "id": "F26",
+                    "technology": "failures",
+                    "title": "Failure of Success Criterion 1.3.3 due to using a graphical symbol alone to convey information"
+                  }
+                ]
               }
             },
             {
@@ -437,9 +1553,26 @@
                   "text": "Examples where a particular display orientation may be essential are a bank check, a piano application, slides for a projector or television, or virtual reality content where content is not necessarily restricted to landscape or portrait display orientation."
                 }
               ],
-              "techniquesHtml": {
-                "sufficient": "<ul>\n          \t\t\t<li><a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G214\">G214: Using a control to allow access to content in different orientations which is otherwise restricted</a></li>\n\t\t\t\t</ul>",
-                "failure": "<ul>\n\t\t\t\t\t<li><a href=\"https://www.w3.org/WAI/WCAG22/Techniques/failures/F97\">F97: Failure due to locking the orientation to landscape or portrait view</a></li>\n\t\t\t\t\t<li><a href=\"https://www.w3.org/WAI/WCAG22/Techniques/failures/F100\">F100: Failure of Success Criterion 1.3.4 due to showing a message asking to reorient device</a></li>\n\t\t\t\t</ul>"
+              "techniques": {
+                "sufficient": [
+                  {
+                    "id": "G214",
+                    "technology": "general",
+                    "title": "Using a control to allow access to content in different orientations which is otherwise restricted"
+                  }
+                ],
+                "failure": [
+                  {
+                    "id": "F97",
+                    "technology": "failures",
+                    "title": "Failure due to locking the orientation to landscape or portrait view"
+                  },
+                  {
+                    "id": "F100",
+                    "technology": "failures",
+                    "title": "Failure of Success Criterion 1.3.4 due to showing a message asking to reorient device"
+                  }
+                ]
               }
             },
             {
@@ -466,9 +1599,21 @@
                   ]
                 }
               ],
-              "techniquesHtml": {
-                "sufficient": "<ul>\n      <li><a href=\"https://www.w3.org/WAI/WCAG22/Techniques/html/H98\">H98: Using HTML 5.2 autocomplete attributes</a></li>\n    </ul>",
-                "failure": "<ul>\n      <li><a href=\"https://www.w3.org/WAI/WCAG22/Techniques/failures/F107\">F107: Failure of Success Criterion 1.3.5 due to incorrect autocomplete attribute values</a></li>\n    </ul>"
+              "techniques": {
+                "sufficient": [
+                  {
+                    "id": "H98",
+                    "technology": "html",
+                    "title": "Using HTML autocomplete attributes"
+                  }
+                ],
+                "failure": [
+                  {
+                    "id": "F107",
+                    "technology": "failures",
+                    "title": "Failure of Success Criterion 1.3.5 due to incorrect autocomplete attribute values"
+                  }
+                ]
               }
             },
             {
@@ -483,9 +1628,31 @@
               ],
               "level": "AAA",
               "details": [],
-              "techniquesHtml": {
-                "sufficient": "<ul>\n\t\t\t\t\t<li>Programmatically indicating the purpose of icons, regions and user interface components</li>\n\t\t\t\t\t<li><a href=\"https://www.w3.org/WAI/WCAG22/Techniques/aria/ARIA11\">ARIA11: Using ARIA landmarks to identify regions of a page</a> AND</li>\n\t\t\t\t\t<li>Using microdata to markup user interface components (future link)</li>\n\t\t\t\t</ul>",
-                "advisory": "<ul>\n\t\t\t\t\t<li>Enabling user agents to find the version of the content that best fits their needs</li>\n\t\t\t\t\t<li>Using semantics to identify important features (e.g., <code>coga-simplification=\"simplest\"</code>)</li>\n\t\t\t\t\t<li>Using <code>aria-invalid</code> and <code>aria-required</code></li>\n\t\t\t\t</ul>"
+              "techniques": {
+                "sufficient": [
+                  {
+                    "title": "Programmatically indicating the purpose of icons, regions and user interface components"
+                  },
+                  {
+                    "id": "ARIA11",
+                    "technology": "aria",
+                    "title": "Using ARIA landmarks to identify regions of a page"
+                  },
+                  {
+                    "title": "Using microdata to markup user interface components (future link)"
+                  }
+                ],
+                "advisory": [
+                  {
+                    "title": "Enabling user agents to find the version of the content that best fits their needs"
+                  },
+                  {
+                    "title": "Using semantics to identify important features (e.g., <code>coga-simplification=\"simplest\"</code>)"
+                  },
+                  {
+                    "title": "Using <code>aria-invalid</code> and <code>aria-required</code>"
+                  }
+                ]
               }
             }
           ]
@@ -525,19 +1692,73 @@
                   "text": "This success criterion addresses color perception specifically. Other forms of perception are covered in Guideline 1.3 including programmatic access to color and other visual presentation coding."
                 }
               ],
-              "techniquesHtml": {
+              "techniques": {
                 "sufficient": [
                   {
-                    "title": "Situation A: If the color of particular words, backgrounds, or other content is used\n               to indicate information:",
-                    "content": "<ul>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G14\">G14: Ensuring that information conveyed by color differences is also available in text</a>\n               </li>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G205\">G205: Including a text cue for colored form control labels</a>\n               </li>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G182\">G182: Ensuring that additional visual cues are available when text color differences are used to convey information</a>\n               </li>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G183\">G183: Using a contrast ratio of 3:1 with surrounding text and providing additional visual cues on hover for links or controls where color alone is used to identify them</a>\n               </li>\n            </ul>"
+                    "title": "Situation A: If the color of particular words, backgrounds, or other content is used to indicate information:",
+                    "techniques": [
+                      {
+                        "id": "G14",
+                        "technology": "general",
+                        "title": "Ensuring that information conveyed by color differences is also available in text"
+                      },
+                      {
+                        "id": "G205",
+                        "technology": "general",
+                        "title": "Including a text cue for colored form control labels"
+                      },
+                      {
+                        "id": "G182",
+                        "technology": "general",
+                        "title": "Ensuring that additional visual cues are available when text color differences are used to convey information"
+                      },
+                      {
+                        "id": "G183",
+                        "technology": "general",
+                        "title": "Using a contrast ratio of 3:1 with surrounding text and providing additional visual cues on hover for links or controls where color alone is used to identify them"
+                      }
+                    ]
                   },
                   {
                     "title": "Situation B: If color is used within an image to convey information:",
-                    "content": "<ul>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G111\">G111: Using color and pattern</a>\n               </li>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G14\">G14: Ensuring that information conveyed by color differences is also available in text</a>\n               </li>\n            </ul>"
+                    "techniques": [
+                      {
+                        "id": "G111",
+                        "technology": "general",
+                        "title": "Using color and pattern"
+                      },
+                      {
+                        "id": "G14",
+                        "technology": "general",
+                        "title": "Ensuring that information conveyed by color differences is also available in text"
+                      }
+                    ]
                   }
                 ],
-                "advisory": "<ul>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/css/C15\">C15: Using CSS to change the presentation of a user interface component when it receives focus</a>\n            </li>\n         </ul>",
-                "failure": "<ul>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/failures/F13\">F13: Failure of Success Criterion 1.1.1 and 1.4.1 due to having a text alternative that does not include information that is conveyed by color differences in the image</a>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/failures/F73\">F73: Failure of Success Criterion 1.4.1 due to creating links that are not visually evident without color vision</a>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/failures/F81\">F81: Failure of Success Criterion 1.4.1 due to identifying required or error fields using color differences only</a>\n            </li>\n         </ul>"
+                "advisory": [
+                  {
+                    "id": "C15",
+                    "technology": "css",
+                    "title": "Using CSS to change the presentation of a user interface component when it receives focus"
+                  }
+                ],
+                "failure": [
+                  {
+                    "id": "F13",
+                    "technology": "failures",
+                    "title": "Failure of Success Criterion 1.1.1 and 1.4.1 due to having a text alternative that does not include information that is conveyed by color differences in the image"
+                  },
+                  {
+                    "id": "F73",
+                    "technology": "failures",
+                    "title": "Failure of Success Criterion 1.4.1 due to creating links that are not visually evident without color vision"
+                  },
+                  {
+                    "id": "F81",
+                    "technology": "failures",
+                    "title": "Failure of Success Criterion 1.4.1 due to identifying required or error fields using color differences only"
+                  }
+                ]
               }
             },
             {
@@ -561,9 +1782,36 @@
                   "text": "Since any content that does not meet this success criterion can interfere with a user's ability to use the whole page, all content on the web page (whether or not it is used to meet other success criteria) must meet this success criterion. See Conformance Requirement 5: Non-Interference."
                 }
               ],
-              "techniquesHtml": {
-                "sufficient": "<ul>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G60\">G60: Playing a sound that turns off automatically within three seconds</a>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G170\">G170: Providing a control near the beginning of the web page that turns off sounds that play automatically</a>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G171\">G171: Playing sounds only on user request</a>\n            </li>\n         </ul>",
-                "failure": "<ul>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/failures/F23\">F23: Failure of 1.4.2 due to playing a sound longer than 3 seconds where there is no mechanism to turn it off</a>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/failures/F93\">F93: Failure of Success Criterion 1.4.2 for absence of a way to pause or stop an HTML5 media element that autoplays</a>\n            </li>\n         </ul>"
+              "techniques": {
+                "sufficient": [
+                  {
+                    "id": "G60",
+                    "technology": "general",
+                    "title": "Playing a sound that turns off automatically within three seconds"
+                  },
+                  {
+                    "id": "G170",
+                    "technology": "general",
+                    "title": "Providing a control near the beginning of the web page that turns off sounds that play automatically"
+                  },
+                  {
+                    "id": "G171",
+                    "technology": "general",
+                    "title": "Playing sounds only on user request"
+                  }
+                ],
+                "failure": [
+                  {
+                    "id": "F23",
+                    "technology": "failures",
+                    "title": "Failure of 1.4.2 due to playing a sound longer than 3 seconds where there is no mechanism to turn it off"
+                  },
+                  {
+                    "id": "F93",
+                    "technology": "failures",
+                    "title": "Failure of Success Criterion 1.4.2 for absence of a way to pause or stop an HTML5 media element that autoplays"
+                  }
+                ]
               }
             },
             {
@@ -599,19 +1847,68 @@
                   ]
                 }
               ],
-              "techniquesHtml": {
+              "techniques": {
                 "sufficient": [
                   {
                     "title": "Situation A: text is less than 18 point if not bold and less than 14 point if bold",
-                    "content": "<ul>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G18\">G18: Ensuring that a contrast ratio of at least 4.5:1 exists between text (and images of text)  and background behind the text</a>\n               </li>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G148\">G148: Not specifying background color, not specifying text color, and not using technology features that change those defaults</a>\n               </li>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G174\">G174: Providing a control with a sufficient contrast ratio that allows users to switch to a presentation that uses sufficient contrast</a>\n               </li>\n            </ul>"
+                    "techniques": [
+                      {
+                        "id": "G18",
+                        "technology": "general",
+                        "title": "Ensuring that a contrast ratio of at least 4.5:1 exists between text (and images of text)  and background behind the text"
+                      },
+                      {
+                        "id": "G148",
+                        "technology": "general",
+                        "title": "Not specifying background color, not specifying text color, and not using technology features that change those defaults"
+                      },
+                      {
+                        "id": "G174",
+                        "technology": "general",
+                        "title": "Providing a control with a sufficient contrast ratio that allows users to switch to a presentation that uses sufficient contrast"
+                      }
+                    ]
                   },
                   {
                     "title": "Situation B: text is at least 18 point if not bold and at least 14 point if bold",
-                    "content": "<ul>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G145\">G145: Ensuring that a contrast ratio of at least 3:1 exists between text (and images of text)  and background behind the text</a>\n               </li>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G148\">G148: Not specifying background color, not specifying text color, and not using technology features that change those defaults</a>\n               </li>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G174\">G174: Providing a control with a sufficient contrast ratio that allows users to switch to a presentation that uses sufficient contrast</a>\n               </li>\n            </ul>"
+                    "techniques": [
+                      {
+                        "id": "G145",
+                        "technology": "general",
+                        "title": "Ensuring that a contrast ratio of at least 3:1 exists between text (and images of text)  and background behind the text"
+                      },
+                      {
+                        "id": "G148",
+                        "technology": "general",
+                        "title": "Not specifying background color, not specifying text color, and not using technology features that change those defaults"
+                      },
+                      {
+                        "id": "G174",
+                        "technology": "general",
+                        "title": "Providing a control with a sufficient contrast ratio that allows users to switch to a presentation that uses sufficient contrast"
+                      }
+                    ]
                   }
                 ],
-                "advisory": "<ul>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G156\">G156: Using a technology that has commonly-available user agents that can change the foreground and background of blocks of text</a>\n            </li>\n         </ul>",
-                "failure": "<ul>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/failures/F24\">F24: Failure of Success Criterion 1.4.3, 1.4.6 and 1.4.8 due to specifying foreground colors without specifying background colors or vice versa</a>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/failures/F83\">F83: Failure of Success Criterion 1.4.3 and 1.4.6 due to using background images that do not provide sufficient contrast with foreground text (or images of text)</a>\n            </li>\n         </ul>"
+                "advisory": [
+                  {
+                    "id": "G156",
+                    "technology": "general",
+                    "title": "Using a technology that has commonly-available user agents that can change the foreground and background of blocks of text"
+                  }
+                ],
+                "failure": [
+                  {
+                    "id": "F24",
+                    "technology": "failures",
+                    "title": "Failure of Success Criterion 1.4.3, 1.4.6 and 1.4.8 due to specifying foreground colors without specifying background colors or vice versa"
+                  },
+                  {
+                    "id": "F83",
+                    "technology": "failures",
+                    "title": "Failure of Success Criterion 1.4.3 and 1.4.6 due to using background images that do not provide sufficient contrast with foreground text (or images of text)"
+                  }
+                ]
               }
             },
             {
@@ -629,10 +1926,110 @@
               ],
               "level": "AA",
               "details": [],
-              "techniquesHtml": {
-                "sufficient": "<ol>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G142\">G142: Using a technology that has commonly-available user agents that support zoom</a>\n            </li>\n            <li>\n               <p>\n                  Ensuring that text containers resize when the text resizes \n                  <strong>AND</strong> using measurements that are relative to other measurements in the content  by using\n                  one or more of the following techniques:\n               </p>\n               <ul>\n                  <li>\n                     <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/css/C28\">C28: Specifying the size of text containers using em units</a>\n                  </li>\n                  <li>\n                     <p>Techniques for relative measurements</p>\n                     <ul>\n                        <li>\n                           <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/css/C12\">C12: Using percent for font sizes</a>\n                        </li>\n                        <li>\n                           <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/css/C13\">C13: Using named font sizes</a>\n                        </li>\n                        <li>\n                           <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/css/C14\">C14: Using em units for font sizes</a>\n                        </li>\n                     </ul>\n                  </li>\n                  <li>\n                     <p>Techniques for text container resizing</p>\n                     <ul>\n                        <li>\n                           <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/client-side-script/SCR34\">SCR34: Calculating size and position in a way that scales with text size</a>\n                        </li>\n                        <li>\n                           <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G146\">G146: Using liquid layout</a>\n                        </li>\n                     </ul>\n                  </li>\n               </ul>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G178\">G178: Providing controls on the web page that allow users to incrementally change the size of all text on the page up to 200 percent</a>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G179\">G179: Ensuring that there is no loss of content or functionality when the text resizes and text containers do not change their width</a>\n            </li>\n      </ol>",
-                "advisory": "<ul>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/css/C17\">C17: Scaling form elements which contain text</a>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/css/C20\">C20: Using relative measurements to set column widths so that lines can average 80 characters or less when the browser is resized</a>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/css/C22\">C22: Using CSS to control visual presentation of text</a>\n            </li>\n         </ul>",
-                "failure": "<ul>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/failures/F69\">F69: Failure of Success Criterion 1.4.4 when resizing visually rendered text up to 200 percent causes the text, image or controls to be clipped, truncated or obscured</a>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/failures/F80\">F80: Failure of Success Criterion 1.4.4 when text-based form controls do not resize when visually rendered text is resized up to 200%</a>\n            </li>\n            <li><a href=\"https://www.w3.org/WAI/WCAG22/Techniques/failures/F94\">F94: Failure of Success Criterion 1.4.4 due to incorrect use of viewport units to resize text</a></li>\n         </ul>"
+              "techniques": {
+                "sufficient": [
+                  {
+                    "id": "G142",
+                    "technology": "general",
+                    "title": "Using a technology that has commonly-available user agents that support zoom"
+                  },
+                  {
+                    "and": [
+                      {
+                        "title": "Ensuring that text containers resize when the text resizes"
+                      },
+                      {
+                        "title": "using measurements that are relative to other measurements in the content"
+                      }
+                    ],
+                    "using": [
+                      {
+                        "id": "C28",
+                        "technology": "css",
+                        "title": "Specifying the size of text containers using em units"
+                      },
+                      {
+                        "title": "Techniques for relative measurements",
+                        "using": [
+                          {
+                            "id": "C12",
+                            "technology": "css",
+                            "title": "Using percent for font sizes"
+                          },
+                          {
+                            "id": "C13",
+                            "technology": "css",
+                            "title": "Using named font sizes"
+                          },
+                          {
+                            "id": "C14",
+                            "technology": "css",
+                            "title": "Using em units for font sizes"
+                          }
+                        ]
+                      },
+                      {
+                        "title": "Techniques for text container resizing",
+                        "using": [
+                          {
+                            "id": "SCR34",
+                            "technology": "client-side-script",
+                            "title": "Calculating size and position in a way that scales with text size"
+                          },
+                          {
+                            "id": "G146",
+                            "technology": "general",
+                            "title": "Using liquid layout"
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "id": "G178",
+                    "technology": "general",
+                    "title": "Providing controls on the web page that allow users to incrementally change the size of all text on the page up to 200 percent"
+                  },
+                  {
+                    "id": "G179",
+                    "technology": "general",
+                    "title": "Ensuring that there is no loss of content or functionality when the text resizes and text containers do not change their width"
+                  }
+                ],
+                "advisory": [
+                  {
+                    "id": "C17",
+                    "technology": "css",
+                    "title": "Scaling form elements which contain text"
+                  },
+                  {
+                    "id": "C20",
+                    "technology": "css",
+                    "title": "Using relative measurements to set column widths so that lines can average 80 characters or less when the browser is resized"
+                  },
+                  {
+                    "id": "C22",
+                    "technology": "css",
+                    "title": "Using CSS to control visual presentation of text"
+                  }
+                ],
+                "failure": [
+                  {
+                    "id": "F69",
+                    "technology": "failures",
+                    "title": "Failure of Success Criterion 1.4.4 when resizing visually rendered text up to 200 percent causes the text, image or controls to be clipped, truncated or obscured"
+                  },
+                  {
+                    "id": "F80",
+                    "technology": "failures",
+                    "title": "Failure of Success Criterion 1.4.4 when text-based form controls do not resize when visually rendered text is resized up to 200%"
+                  },
+                  {
+                    "id": "F94",
+                    "technology": "failures",
+                    "title": "Failure of Success Criterion 1.4.4 due to incorrect use of viewport units to resize text"
+                  }
+                ]
               }
             },
             {
@@ -669,9 +2066,56 @@
                   "text": "Logotypes (text that is part of a logo or brand name) are considered essential."
                 }
               ],
-              "techniquesHtml": {
-                "sufficient": "<ul>\n            <li><a href=\"https://www.w3.org/WAI/WCAG22/Techniques/css/C22\">C22: Using CSS to control visual presentation of text</a></li>\n            <li><a href=\"https://www.w3.org/WAI/WCAG22/Techniques/css/C30\">C30: Using CSS to replace text with images of text and providing user interface controls to switch</a></li>\n            <li><a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G140\">G140: Separating information and structure from presentation to enable different presentations</a></li>\n            <li><a href=\"https://www.w3.org/WAI/WCAG22/Techniques/pdf/PDF7\">PDF7: Performing OCR on a scanned PDF document to provide actual text</a></li>\n         </ul>",
-                "advisory": "<ul>\n               <li><a href=\"https://www.w3.org/WAI/WCAG22/Techniques/css/C12\">C12: Using percent for font sizes</a></li>\n               <li><a href=\"https://www.w3.org/WAI/WCAG22/Techniques/css/C13\">C13: Using named font sizes</a></li>\n               <li><a href=\"https://www.w3.org/WAI/WCAG22/Techniques/css/C14\">C14: Using em units for font sizes</a></li>\n               <li><a href=\"https://www.w3.org/WAI/WCAG22/Techniques/css/C8\">C8: Using CSS letter-spacing to control spacing within a word</a></li>\n               <li><a href=\"https://www.w3.org/WAI/WCAG22/Techniques/css/C6\">C6: Positioning content based on structural markup</a></li>\n            </ul>"
+              "techniques": {
+                "sufficient": [
+                  {
+                    "id": "C22",
+                    "technology": "css",
+                    "title": "Using CSS to control visual presentation of text"
+                  },
+                  {
+                    "id": "C30",
+                    "technology": "css",
+                    "title": "Using CSS to replace text with images of text and providing user interface controls to switch"
+                  },
+                  {
+                    "id": "G140",
+                    "technology": "general",
+                    "title": "Separating information and structure from presentation to enable different presentations"
+                  },
+                  {
+                    "id": "PDF7",
+                    "technology": "pdf",
+                    "title": "Performing OCR on a scanned PDF document to provide actual text"
+                  }
+                ],
+                "advisory": [
+                  {
+                    "id": "C12",
+                    "technology": "css",
+                    "title": "Using percent for font sizes"
+                  },
+                  {
+                    "id": "C13",
+                    "technology": "css",
+                    "title": "Using named font sizes"
+                  },
+                  {
+                    "id": "C14",
+                    "technology": "css",
+                    "title": "Using em units for font sizes"
+                  },
+                  {
+                    "id": "C8",
+                    "technology": "css",
+                    "title": "Using CSS letter-spacing to control spacing within a word"
+                  },
+                  {
+                    "id": "C6",
+                    "technology": "css",
+                    "title": "Positioning content based on structural markup"
+                  }
+                ]
               }
             },
             {
@@ -707,19 +2151,68 @@
                   ]
                 }
               ],
-              "techniquesHtml": {
+              "techniques": {
                 "sufficient": [
                   {
                     "title": "Situation A: text is less than 18 point if not bold and less than 14 point if bold",
-                    "content": "<ul>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G17\">G17: Ensuring that a contrast ratio of at least 7:1 exists between text (and images of text) and background behind the text</a>\n               </li>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G148\">G148: Not specifying background color, not specifying text color, and not using technology features that change those defaults</a>\n               </li>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G174\">G174: Providing a control with a sufficient contrast ratio that allows users to switch to a presentation that uses sufficient contrast</a>\n               </li>\n            </ul>"
+                    "techniques": [
+                      {
+                        "id": "G17",
+                        "technology": "general",
+                        "title": "Ensuring that a contrast ratio of at least 7:1 exists between text (and images of text) and background behind the text"
+                      },
+                      {
+                        "id": "G148",
+                        "technology": "general",
+                        "title": "Not specifying background color, not specifying text color, and not using technology features that change those defaults"
+                      },
+                      {
+                        "id": "G174",
+                        "technology": "general",
+                        "title": "Providing a control with a sufficient contrast ratio that allows users to switch to a presentation that uses sufficient contrast"
+                      }
+                    ]
                   },
                   {
                     "title": "Situation B: text is as least 18 point if not bold and at least 14 point if bold",
-                    "content": "<ul>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G18\">G18: Ensuring that a contrast ratio of at least 4.5:1 exists between text (and images of text)  and background behind the text</a>\n               </li>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G148\">G148: Not specifying background color, not specifying text color, and not using technology features that change those defaults</a>\n               </li>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G174\">G174: Providing a control with a sufficient contrast ratio that allows users to switch to a presentation that uses sufficient contrast</a>\n               </li>\n            </ul>"
+                    "techniques": [
+                      {
+                        "id": "G18",
+                        "technology": "general",
+                        "title": "Ensuring that a contrast ratio of at least 4.5:1 exists between text (and images of text)  and background behind the text"
+                      },
+                      {
+                        "id": "G148",
+                        "technology": "general",
+                        "title": "Not specifying background color, not specifying text color, and not using technology features that change those defaults"
+                      },
+                      {
+                        "id": "G174",
+                        "technology": "general",
+                        "title": "Providing a control with a sufficient contrast ratio that allows users to switch to a presentation that uses sufficient contrast"
+                      }
+                    ]
                   }
                 ],
-                "advisory": "<ul>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G156\">G156: Using a technology that has commonly-available user agents that can change the foreground and background of blocks of text</a>\n            </li>\n         </ul>",
-                "failure": "<ul>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/failures/F24\">F24: Failure of Success Criterion 1.4.3, 1.4.6 and 1.4.8 due to specifying foreground colors without specifying background colors or vice versa</a>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/failures/F83\">F83: Failure of Success Criterion 1.4.3 and 1.4.6 due to using background images that do not provide sufficient contrast with foreground text (or images of text)</a>\n            </li>\n         </ul>"
+                "advisory": [
+                  {
+                    "id": "G156",
+                    "technology": "general",
+                    "title": "Using a technology that has commonly-available user agents that can change the foreground and background of blocks of text"
+                  }
+                ],
+                "failure": [
+                  {
+                    "id": "F24",
+                    "technology": "failures",
+                    "title": "Failure of Success Criterion 1.4.3, 1.4.6 and 1.4.8 due to specifying foreground colors without specifying background colors or vice versa"
+                  },
+                  {
+                    "id": "F83",
+                    "technology": "failures",
+                    "title": "Failure of Success Criterion 1.4.3 and 1.4.6 due to using background images that do not provide sufficient contrast with foreground text (or images of text)"
+                  }
+                ]
               }
             },
             {
@@ -760,8 +2253,14 @@
                   "text": "Per the definition of \"decibel,\" background sound that meets this requirement will be approximately four times quieter than the foreground speech content."
                 }
               ],
-              "techniquesHtml": {
-                "sufficient": "<ul>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G56\">G56: Mixing audio files so that non-speech sounds are at least 20 decibels lower than the speech audio content</a>\n            </li>\n         </ul>"
+              "techniques": {
+                "sufficient": [
+                  {
+                    "id": "G56",
+                    "technology": "general",
+                    "title": "Mixing audio files so that non-speech sounds are at least 20 decibels lower than the speech audio content"
+                  }
+                ]
               }
             },
             {
@@ -810,30 +2309,155 @@
                   "text": "Writing systems for some languages use different presentation aspects to improve readability and legibility. If a presentation aspect in this success criterion is not used in a writing system, content in that writing system does not need to use that presentation setting and can conform without it. Authors are encouraged to follow guidance for improving readability and legibility of text in their writing system."
                 }
               ],
-              "techniquesHtml": {
+              "techniques": {
                 "sufficient": [
                   {
                     "title": "First Requirement: Techniques to ensure foreground and background colors can be selected by the user",
-                    "content": "<ul>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/css/C23\">C23: Specifying text and background colors of secondary content such as banners, features and navigation in CSS while not specifying text and background colors of the main content</a> OR \n               </li>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/css/C25\">C25: Specifying borders and layout in CSS to delineate areas of a web page while not specifying text and text-background colors</a> OR \n               </li>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G156\">G156: Using a technology that has commonly-available user agents that can change the foreground and background of blocks of text</a> OR \n               </li>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G148\">G148: Not specifying background color, not specifying text color, and not using technology features that change those defaults</a> OR \n               </li>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G175\">G175: Providing a multi color selection tool on the page for foreground and background colors</a>\n               </li>\n            </ul>"
+                    "techniques": [
+                      {
+                        "id": "C23",
+                        "technology": "css",
+                        "title": "Specifying text and background colors of secondary content such as banners, features and navigation in CSS while not specifying text and background colors of the main content"
+                      },
+                      {
+                        "id": "C25",
+                        "technology": "css",
+                        "title": "Specifying borders and layout in CSS to delineate areas of a web page while not specifying text and text-background colors"
+                      },
+                      {
+                        "id": "G156",
+                        "technology": "general",
+                        "title": "Using a technology that has commonly-available user agents that can change the foreground and background of blocks of text"
+                      },
+                      {
+                        "id": "G148",
+                        "technology": "general",
+                        "title": "Not specifying background color, not specifying text color, and not using technology features that change those defaults"
+                      },
+                      {
+                        "id": "G175",
+                        "technology": "general",
+                        "title": "Providing a multi color selection tool on the page for foreground and background colors"
+                      }
+                    ]
                   },
                   {
                     "title": "Second Requirement: Techniques to ensure width is no more than 80 characters or glyphs (40 if CJK)",
-                    "content": "<ul>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G204\">G204: Not interfering with the user agent's reflow of text as the viewing window is narrowed</a> OR\n               </li>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/css/C20\">C20: Using relative measurements to set column widths so that lines can average 80 characters or less when the browser is resized</a>\n               </li>\n            </ul>"
+                    "techniques": [
+                      {
+                        "id": "G204",
+                        "technology": "general",
+                        "title": "Not interfering with the user agent's reflow of text as the viewing window is narrowed"
+                      },
+                      {
+                        "id": "C20",
+                        "technology": "css",
+                        "title": "Using relative measurements to set column widths so that lines can average 80 characters or less when the browser is resized"
+                      }
+                    ]
                   },
                   {
                     "title": "Third Requirement: Techniques to ensure text is not justified (aligned to both the left and the right margins)",
-                    "content": "<ul>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/css/C19\">C19: Specifying alignment either to the left or right in CSS</a> OR\n               </li>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G172\">G172: Providing a mechanism to remove full justification of text</a> OR \n               </li>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G169\">G169: Aligning text on only one side</a>\n               </li>\n            </ul>"
+                    "techniques": [
+                      {
+                        "id": "C19",
+                        "technology": "css",
+                        "title": "Specifying alignment either to the left or right in CSS"
+                      },
+                      {
+                        "id": "G172",
+                        "technology": "general",
+                        "title": "Providing a mechanism to remove full justification of text"
+                      },
+                      {
+                        "id": "G169",
+                        "technology": "general",
+                        "title": "Aligning text on only one side"
+                      }
+                    ]
                   },
                   {
-                    "title": "Fourth Requirement: Techniques to ensure line spacing (leading) is at least space-and-a-half within paragraphs,\n              and paragraph spacing is at least 1.5 times larger than the line spacing",
-                    "content": "<ul>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G188\">G188: Providing a button on the page to increase line spaces and paragraph spaces</a> OR\n               </li>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/css/C21\">C21: Specifying line spacing in CSS</a>\n               </li>\n            </ul>"
+                    "title": "Fourth Requirement: Techniques to ensure line spacing (leading) is at least space-and-a-half within paragraphs, and paragraph spacing is at least 1.5 times larger than the line spacing",
+                    "techniques": [
+                      {
+                        "id": "G188",
+                        "technology": "general",
+                        "title": "Providing a button on the page to increase line spaces and paragraph spaces"
+                      },
+                      {
+                        "id": "C21",
+                        "technology": "css",
+                        "title": "Specifying line spacing in CSS"
+                      }
+                    ]
                   },
                   {
-                    "title": "Fifth Requirement: Techniques to ensure text can be resized without assistive technology up to 200 percent in a way that\n              does not require the user to scroll horizontally to read a line of text on a full-screen window",
-                    "content": "<ul>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G204\">G204: Not interfering with the user agent's reflow of text as the viewing window is narrowed</a> OR\n               </li>\n               <li>\n                  <p> \n                     <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G146\">G146: Using liquid layout</a>\n                     <em>AND</em> using measurements that are relative to other measurements in the content by using\n                     one or more of the following techniques:\n                  </p>\n                  <ul>\n                     <li> \n                        <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/css/C12\">C12: Using percent for font sizes</a> OR \n                     </li>\n                     <li> \n                        <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/css/C13\">C13: Using named font sizes</a> OR \n                     </li>\n                     <li> \n                        <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/css/C14\">C14: Using em units for font sizes</a> OR \n                     </li>\n                     <li>\n                        <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/css/C24\">C24: Using percentage values in CSS for container sizes</a> OR \n                     </li>\n                     <li>\n                        <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/client-side-script/SCR34\">SCR34: Calculating size and position in a way that scales with text size</a> OR \n                     </li>\n                  </ul>\n               </li>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G206\">G206: Providing options within the content to switch to a layout that does not require the user to scroll horizontally to read a line of text</a>\n               </li>\n            </ul>"
+                    "title": "Fifth Requirement: Techniques to ensure text can be resized without assistive technology up to 200 percent in a way that does not require the user to scroll horizontally to read a line of text on a full-screen window",
+                    "techniques": [
+                      {
+                        "id": "G204",
+                        "technology": "general",
+                        "title": "Not interfering with the user agent's reflow of text as the viewing window is narrowed"
+                      },
+                      {
+                        "and": [
+                          {
+                            "id": "G146",
+                            "technology": "general",
+                            "title": "Using liquid layout"
+                          },
+                          {
+                            "title": "using measurements that are relative to other measurements in the content"
+                          }
+                        ],
+                        "using": [
+                          {
+                            "id": "C12",
+                            "technology": "css",
+                            "title": "Using percent for font sizes"
+                          },
+                          {
+                            "id": "C13",
+                            "technology": "css",
+                            "title": "Using named font sizes"
+                          },
+                          {
+                            "id": "C14",
+                            "technology": "css",
+                            "title": "Using em units for font sizes"
+                          },
+                          {
+                            "id": "C24",
+                            "technology": "css",
+                            "title": "Using percentage values in CSS for container sizes"
+                          },
+                          {
+                            "id": "SCR34",
+                            "technology": "client-side-script",
+                            "title": "Calculating size and position in a way that scales with text size"
+                          }
+                        ]
+                      },
+                      {
+                        "id": "G206",
+                        "technology": "general",
+                        "title": "Providing options within the content to switch to a layout that does not require the user to scroll horizontally to read a line of text"
+                      }
+                    ]
                   }
                 ],
-                "failure": "<ul>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/failures/F24\">F24: Failure of Success Criterion 1.4.3, 1.4.6 and 1.4.8 due to specifying foreground colors without specifying background colors or vice versa</a>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/failures/F88\">F88: Failure of Success Criterion 1.4.8 due to using text that is justified (aligned to both the left and the right margins)</a>\n            </li>\n         </ul>"
+                "failure": [
+                  {
+                    "id": "F24",
+                    "technology": "failures",
+                    "title": "Failure of Success Criterion 1.4.3, 1.4.6 and 1.4.8 due to specifying foreground colors without specifying background colors or vice versa"
+                  },
+                  {
+                    "id": "F88",
+                    "technology": "failures",
+                    "title": "Failure of Success Criterion 1.4.8 due to using text that is justified (aligned to both the left and the right margins)"
+                  }
+                ]
               }
             },
             {
@@ -857,9 +2481,56 @@
                   "text": "Logotypes (text that is part of a logo or brand name) are considered essential."
                 }
               ],
-              "techniquesHtml": {
-                "sufficient": "<ul>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/css/C22\">C22: Using CSS to control visual presentation of text</a>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/css/C30\">C30: Using CSS to replace text with images of text and providing user interface controls to switch</a>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G140\">G140: Separating information and structure from presentation to enable different presentations</a>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/pdf/PDF7\">PDF7: Performing OCR on a scanned PDF document to provide actual text</a>\n            </li>\n         </ul>",
-                "advisory": "<ul>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/css/C12\">C12: Using percent for font sizes</a>\n               </li>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/css/C13\">C13: Using named font sizes</a>\n               </li>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/css/C14\">C14: Using em units for font sizes</a>\n               </li>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/css/C8\">C8: Using CSS letter-spacing to control spacing within a word</a>\n               </li>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/css/C6\">C6: Positioning content based on structural markup</a>\n               </li>\n            </ul>"
+              "techniques": {
+                "sufficient": [
+                  {
+                    "id": "C22",
+                    "technology": "css",
+                    "title": "Using CSS to control visual presentation of text"
+                  },
+                  {
+                    "id": "C30",
+                    "technology": "css",
+                    "title": "Using CSS to replace text with images of text and providing user interface controls to switch"
+                  },
+                  {
+                    "id": "G140",
+                    "technology": "general",
+                    "title": "Separating information and structure from presentation to enable different presentations"
+                  },
+                  {
+                    "id": "PDF7",
+                    "technology": "pdf",
+                    "title": "Performing OCR on a scanned PDF document to provide actual text"
+                  }
+                ],
+                "advisory": [
+                  {
+                    "id": "C12",
+                    "technology": "css",
+                    "title": "Using percent for font sizes"
+                  },
+                  {
+                    "id": "C13",
+                    "technology": "css",
+                    "title": "Using named font sizes"
+                  },
+                  {
+                    "id": "C14",
+                    "technology": "css",
+                    "title": "Using em units for font sizes"
+                  },
+                  {
+                    "id": "C8",
+                    "technology": "css",
+                    "title": "Using CSS letter-spacing to control spacing within a word"
+                  },
+                  {
+                    "id": "C6",
+                    "technology": "css",
+                    "title": "Positioning content based on structural markup"
+                  }
+                ]
               }
             },
             {
@@ -900,10 +2571,83 @@
                   "text": "Examples of content which requires two-dimensional layout are images required for understanding (such as maps and diagrams), video, games, presentations, data tables (not individual cells), and interfaces where it is necessary to keep toolbars in view while manipulating content. It is acceptable to provide two-dimensional scrolling for such parts of the content."
                 }
               ],
-              "techniquesHtml": {
-                "sufficient": "<ul>\n            <li><a href=\"https://www.w3.org/WAI/WCAG22/Techniques/css/C32\">C32: Using media queries and grid CSS to reflow columns</a></li>\n            <li><a href=\"https://www.w3.org/WAI/WCAG22/Techniques/css/C31\">C31: Using CSS Flexbox to reflow content</a></li>\n            <li><a href=\"https://www.w3.org/WAI/WCAG22/Techniques/css/C33\">C33: Allowing for Reflow with Long URLs and Strings of Text</a></li>\n            <li><a href=\"https://www.w3.org/WAI/WCAG22/Techniques/css/C38\">C38: Using CSS width, max-width and flexbox to fit labels and inputs</a></li>\n            <li><a href=\"https://www.w3.org/WAI/WCAG22/Techniques/client-side-script/SCR34\">SCR34: Calculating size and position in a way that scales with text size</a></li>\n            <li><a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G206\">G206: Providing options within the content to switch to a layout that does not require the user to scroll horizontally to read a line of text</a></li>\n            <li><a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G224\">G224: Accounting for meaningful text indentation and Reflow</a></li>\n            <li><a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G225\">G225: Section panels that scroll horizontally are designed to fit within a width of 320 CSS pixels on a vertically scrolling page</a></li>\n            <li>Using PDF/UA when creating PDFs (Potential future technique)</li>\n        </ul>",
-                "advisory": "<ul>\n          <li><a href=\"https://www.w3.org/WAI/WCAG22/Techniques/css/C34\">C34: Using media queries to un-fixing sticky headers / footers</a></li>\n          <li><a href=\"https://www.w3.org/WAI/WCAG22/Techniques/css/C37\">C37: Using CSS max-width and height to fit images</a></li>\n          <li>CSS, Reflowing simple data tables (Potential future technique)</li>\n          <li>CSS, Fitting data cells within the width of the viewport (Potential future technique)</li>\n          <li>Mechanism to allow mobile view at any time (Potential future technique)</li>\n          <li>Alternate view supporting Reflow for otherwise excepted content (Potential future technique)</li>\n        </ul>",
-                "failure": "<ul>\n            <li><a href=\"https://www.w3.org/WAI/WCAG22/Techniques/failures/F102\">F102: Failure of Success Criterion 1.4.10 due to content disappearing and not being available when content has reflowed</a></li>\n        </ul>"
+              "techniques": {
+                "sufficient": [
+                  {
+                    "id": "C32",
+                    "technology": "css",
+                    "title": "Using media queries and grid CSS to reflow columns"
+                  },
+                  {
+                    "id": "C31",
+                    "technology": "css",
+                    "title": "Using CSS Flexbox to reflow content"
+                  },
+                  {
+                    "id": "C33",
+                    "technology": "css",
+                    "title": "Allowing for Reflow with Long URLs and Strings of Text"
+                  },
+                  {
+                    "id": "C38",
+                    "technology": "css",
+                    "title": "Using CSS width, max-width and flexbox to fit labels and inputs"
+                  },
+                  {
+                    "id": "SCR34",
+                    "technology": "client-side-script",
+                    "title": "Calculating size and position in a way that scales with text size"
+                  },
+                  {
+                    "id": "G206",
+                    "technology": "general",
+                    "title": "Providing options within the content to switch to a layout that does not require the user to scroll horizontally to read a line of text"
+                  },
+                  {
+                    "id": "G224",
+                    "technology": "general",
+                    "title": "Accounting for meaningful text indentation and Reflow"
+                  },
+                  {
+                    "id": "G225",
+                    "technology": "general",
+                    "title": "Section panels that scroll horizontally are designed to fit within a width of 320 CSS pixels on a vertically scrolling page"
+                  },
+                  {
+                    "title": "Using PDF/UA when creating PDFs (Potential future technique)"
+                  }
+                ],
+                "advisory": [
+                  {
+                    "id": "C34",
+                    "technology": "css",
+                    "title": "Using media queries to un-fixing sticky headers / footers"
+                  },
+                  {
+                    "id": "C37",
+                    "technology": "css",
+                    "title": "Using CSS max-width and height to fit images"
+                  },
+                  {
+                    "title": "CSS, Reflowing simple data tables (Potential future technique)"
+                  },
+                  {
+                    "title": "CSS, Fitting data cells within the width of the viewport (Potential future technique)"
+                  },
+                  {
+                    "title": "Mechanism to allow mobile view at any time (Potential future technique)"
+                  },
+                  {
+                    "title": "Alternate view supporting Reflow for otherwise excepted content (Potential future technique)"
+                  }
+                ],
+                "failure": [
+                  {
+                    "id": "F102",
+                    "technology": "failures",
+                    "title": "Failure of Success Criterion 1.4.10 due to content disappearing and not being available when content has reflowed"
+                  }
+                ]
               }
             },
             {
@@ -932,18 +2676,46 @@
                   ]
                 }
               ],
-              "techniquesHtml": {
+              "techniques": {
                 "sufficient": [
                   {
                     "title": "Situation A: Color is used to identify user interface components or used to identify user interface component states",
-                    "content": "<ul>\n\t\t\t\t\t\t\t<li><a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G195\">G195: Using an author-supplied, visible focus indicator</a></li>\n\t\t\t\t\t\t\t<li><a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G174\">G174: Providing a control with a sufficient contrast ratio that allows users to switch to a presentation that uses sufficient contrast</a></li>\n\t\t\t\t\t\t</ul>"
+                    "techniques": [
+                      {
+                        "id": "G195",
+                        "technology": "general",
+                        "title": "Using an author-supplied, visible focus indicator"
+                      },
+                      {
+                        "id": "G174",
+                        "technology": "general",
+                        "title": "Providing a control with a sufficient contrast ratio that allows users to switch to a presentation that uses sufficient contrast"
+                      }
+                    ]
                   },
                   {
                     "title": "Situation B: Color is required to understand graphical content",
-                    "content": "<ul>\n\t\t\t\t\t\t<li><a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G207\">G207: Ensuring that a contrast ratio of 3:1 is provided for icons</a></li>\n\t\t\t\t\t\t<li><a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G209\">G209: Provide sufficient contrast at the boundaries between adjoining colors</a></li>\n\t\t\t\t\t</ul>"
+                    "techniques": [
+                      {
+                        "id": "G207",
+                        "technology": "general",
+                        "title": "Ensuring that a contrast ratio of 3:1 is provided for icons"
+                      },
+                      {
+                        "id": "G209",
+                        "technology": "general",
+                        "title": "Provide sufficient contrast at the boundaries between adjoining colors"
+                      }
+                    ]
                   }
                 ],
-                "failure": "<ul>\n\t\t\t\t\t<li><a href=\"https://www.w3.org/WAI/WCAG22/Techniques/failures/F78\">F78: Failure of Success Criterion 1.4.11, 2.4.7 and 2.4.13 due to styling element outlines and borders in a way that removes or renders non-visible the visual focus indicator</a></li>\n\t\t\t\t</ul>"
+                "failure": [
+                  {
+                    "id": "F78",
+                    "technology": "failures",
+                    "title": "Failure of Success Criterion 1.4.11, 2.4.7 and 2.4.13 due to styling element outlines and borders in a way that removes or renders non-visible the visual focus indicator"
+                  }
+                ]
               }
             },
             {
@@ -990,10 +2762,43 @@
                   "text": "Writing systems for some languages use different text spacing settings, such as paragraph start indent. Authors are encouraged to follow locally available guidance for improving readability and legibility of text in their writing system."
                 }
               ],
-              "techniquesHtml": {
-                "sufficient": "<ul>\n          <li><a href=\"https://www.w3.org/WAI/WCAG22/Techniques/css/C36\">C36: Allowing for text spacing override</a></li>\n          <li><a href=\"https://www.w3.org/WAI/WCAG22/Techniques/css/C35\">C35: Allowing for text spacing without wrapping</a></li>\n        </ul>",
-                "advisory": "<ul>\n        <li><a href=\"https://www.w3.org/WAI/WCAG22/Techniques/css/C8\">C8: Using CSS letter-spacing to control spacing within a word</a></li>\n        <li><a href=\"https://www.w3.org/WAI/WCAG22/Techniques/css/C21\">C21: Specifying line spacing in CSS</a></li>\n        <li><a href=\"https://www.w3.org/WAI/WCAG22/Techniques/css/C28\">C28: Specifying the size of text containers using em units</a></li>\n      </ul>",
-                "failure": "<ul>\n        <li><a href=\"https://www.w3.org/WAI/WCAG22/Techniques/failures/F104\">F104: Failure of Success Criterion 1.4.12 due to clipped or overlapped content when text spacing is adjusted</a></li>\n      </ul>"
+              "techniques": {
+                "sufficient": [
+                  {
+                    "id": "C36",
+                    "technology": "css",
+                    "title": "Allowing for text spacing override"
+                  },
+                  {
+                    "id": "C35",
+                    "technology": "css",
+                    "title": "Allowing for text spacing without wrapping"
+                  }
+                ],
+                "advisory": [
+                  {
+                    "id": "C8",
+                    "technology": "css",
+                    "title": "Using CSS letter-spacing to control spacing within a word"
+                  },
+                  {
+                    "id": "C21",
+                    "technology": "css",
+                    "title": "Specifying line spacing in CSS"
+                  },
+                  {
+                    "id": "C28",
+                    "technology": "css",
+                    "title": "Specifying the size of text containers using em units"
+                  }
+                ],
+                "failure": [
+                  {
+                    "id": "F104",
+                    "technology": "failures",
+                    "title": "Failure of Success Criterion 1.4.12 due to clipped or overlapped content when text spacing is adjusted"
+                  }
+                ]
               }
             },
             {
@@ -1045,9 +2850,33 @@
                   "text": "This criterion applies to content that appears in addition to the triggering component itself. Since hidden components that are made visible on keyboard focus (such as links used to skip to another part of a page) do not present additional content they are not covered by this criterion."
                 }
               ],
-              "techniquesHtml": {
-                "sufficient": "<ul>\n\t\t\t\t\t\t<li><a href=\"https://www.w3.org/WAI/WCAG22/Techniques/client-side-script/SCR39\">SCR39: Making content on focus or hover hoverable, dismissible, and persistent</a></li>\n\t\t\t\t\t\t<li>ARIA: Using role=\"tooltip\" (Potential future technique)</li>\n\t\t\t\t\t\t<li>CSS: Using hover and focus pseudo classes (Potential future technique)</li>\n\t\t\t\t\t</ul>",
-                "failure": "<ul>\n\t\t\t\t\t<li><a href=\"https://www.w3.org/WAI/WCAG22/Techniques/failures/F95\">F95: Failure of Success Criterion 1.4.13 due to content shown on hover not being hoverable</a></li>\n\t\t\t\t\t<li>Failure to make content dismissible without moving pointer hover or keyboard focus (Potential future technique)</li>\n\t\t\t\t\t<li>Failure to meet by content on hover or focus not remaining visible until dismissed or invalid (Potential future technique)</li>\n\t\t\t\t</ul>"
+              "techniques": {
+                "sufficient": [
+                  {
+                    "id": "SCR39",
+                    "technology": "client-side-script",
+                    "title": "Making content on focus or hover hoverable, dismissible, and persistent"
+                  },
+                  {
+                    "title": "ARIA: Using role=\"tooltip\" (Potential future technique)"
+                  },
+                  {
+                    "title": "CSS: Using hover and focus pseudo classes (Potential future technique)"
+                  }
+                ],
+                "failure": [
+                  {
+                    "id": "F95",
+                    "technology": "failures",
+                    "title": "Failure of Success Criterion 1.4.13 due to content shown on hover not being hoverable"
+                  },
+                  {
+                    "title": "Failure to make content dismissible without moving pointer hover or keyboard focus (Potential future technique)"
+                  },
+                  {
+                    "title": "Failure to meet by content on hover or focus not remaining visible until dismissed or invalid (Potential future technique)"
+                  }
+                ]
               }
             }
           ]
@@ -1105,10 +2934,94 @@
                   "text": "This does not forbid and should not discourage providing mouse input or other input methods in addition to keyboard operation."
                 }
               ],
-              "techniquesHtml": {
-                "sufficient": "<ul>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G202\">G202: Ensuring keyboard control for all functionality</a>\n            </li>\n            <li>\n               <p>Ensuring keyboard control by using one of the following techniques.</p>\n               <ul>\n                  <li>\n                     <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/html/H91\">H91: Using HTML form controls and links</a>\n                  </li>\n                  <li>\n                     <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/pdf/PDF3\">PDF3: Ensuring correct tab and reading order in PDF documents</a>\n                  </li>\n                  <li>\n                     <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/pdf/PDF11\">PDF11: Providing links and link text using the Link annotation and the /Link structure element in PDF documents</a>\n                  </li>\n                  <li>\n                     <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/pdf/PDF23\">PDF23: Providing interactive form controls in PDF documents</a>\n                  </li>\n               </ul>\n            </li>\n            <li>\n               <p> \n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G90\">G90: Providing keyboard-triggered event handlers</a> using one of the following techniques:     \n               </p>\n               <ul>\n                  <li>\n                     <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/client-side-script/SCR20\">SCR20: Using both keyboard and other device-specific functions</a>\n                  </li>\n                  <li>\n                     <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/client-side-script/SCR35\">SCR35: Making actions keyboard accessible by using the onclick event of anchors and buttons</a>\n                  </li>\n                  <li>\n                     <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/client-side-script/SCR2\">SCR2: Using redundant keyboard and mouse event handlers</a>\n                  </li>\n               </ul>\n            </li>\n         </ul>",
-                "advisory": "<ul>\n            <li>Using WAi-ARIA role, state, and value attributes if repurposing static elements as interactive\n               user interface components (future link) AND \n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/client-side-script/SCR29\">SCR29: Adding keyboard-accessible actions to static HTML elements</a>\n            </li>\n         </ul>",
-                "failure": "<ul>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/failures/F54\">F54: Failure of Success Criterion 2.1.1 due to using only pointing-device-specific event handlers (including gesture) for a function</a>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/failures/F55\">F55: Failure of Success Criteria 2.1.1, 2.4.7, 2.4.13, and 3.2.1 due to using script to remove focus when focus is received</a>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/failures/F42\">F42: Failure of Success Criteria 1.3.1, 2.1.1, 2.1.3, or 4.1.2 when emulating links</a>\n            </li>\n         </ul>"
+              "techniques": {
+                "sufficient": [
+                  {
+                    "id": "G202",
+                    "technology": "general",
+                    "title": "Ensuring keyboard control for all functionality"
+                  },
+                  {
+                    "title": "Ensuring keyboard control",
+                    "suffix": "using one of the following techniques:",
+                    "using": [
+                      {
+                        "id": "H91",
+                        "technology": "html",
+                        "title": "Using HTML form controls and links"
+                      },
+                      {
+                        "id": "PDF3",
+                        "technology": "pdf",
+                        "title": "Ensuring correct tab and reading order in PDF documents"
+                      },
+                      {
+                        "id": "PDF11",
+                        "technology": "pdf",
+                        "title": "Providing links and link text using the Link annotation and the /Link structure element in PDF documents"
+                      },
+                      {
+                        "id": "PDF23",
+                        "technology": "pdf",
+                        "title": "Providing interactive form controls in PDF documents"
+                      }
+                    ]
+                  },
+                  {
+                    "id": "G90",
+                    "technology": "general",
+                    "title": "Providing keyboard-triggered event handlers",
+                    "suffix": "using one of the following techniques:",
+                    "using": [
+                      {
+                        "id": "SCR20",
+                        "technology": "client-side-script",
+                        "title": "Using both keyboard and other device-specific functions"
+                      },
+                      {
+                        "id": "SCR35",
+                        "technology": "client-side-script",
+                        "title": "Making actions keyboard accessible by using the onclick event of anchors and buttons"
+                      },
+                      {
+                        "id": "SCR2",
+                        "technology": "client-side-script",
+                        "title": "Using redundant keyboard and mouse event handlers"
+                      }
+                    ]
+                  }
+                ],
+                "advisory": [
+                  {
+                    "and": [
+                      {
+                        "title": "Using WAI-ARIA role, state, and value attributes if repurposing static elements as interactive user interface components (future link)"
+                      },
+                      {
+                        "id": "SCR29",
+                        "technology": "client-side-script",
+                        "title": "Adding keyboard-accessible actions to static HTML elements"
+                      }
+                    ]
+                  }
+                ],
+                "failure": [
+                  {
+                    "id": "F54",
+                    "technology": "failures",
+                    "title": "Failure of Success Criterion 2.1.1 due to using only pointing-device-specific event handlers (including gesture) for a function"
+                  },
+                  {
+                    "id": "F55",
+                    "technology": "failures",
+                    "title": "Failure of Success Criteria 2.1.1, 2.4.7, 2.4.13, and 3.2.1 due to using script to remove focus when focus is received"
+                  },
+                  {
+                    "id": "F42",
+                    "technology": "failures",
+                    "title": "Failure of Success Criteria 1.3.1, 2.1.1, 2.1.3, or 4.1.2 when emulating links"
+                  }
+                ]
               }
             },
             {
@@ -1132,9 +3045,21 @@
                   "text": "Since any content that does not meet this success criterion can interfere with a user's ability to use the whole page, all content on the web page (whether it is used to meet other success criteria or not) must meet this success criterion. See Conformance Requirement 5: Non-Interference."
                 }
               ],
-              "techniquesHtml": {
-                "sufficient": "<ul>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G21\">G21: Ensuring that users are not trapped in content</a>\n            </li>\n         </ul>",
-                "failure": "<ul>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/failures/F10\">F10: Failure of Success Criterion 2.1.2 and Conformance Requirement 5 due to combining multiple content formats in a way that traps users inside one format type</a>\n            </li>\n         </ul>"
+              "techniques": {
+                "sufficient": [
+                  {
+                    "id": "G21",
+                    "technology": "general",
+                    "title": "Ensuring that users are not trapped in content"
+                  }
+                ],
+                "failure": [
+                  {
+                    "id": "F10",
+                    "technology": "failures",
+                    "title": "Failure of Success Criterion 2.1.2 and Conformance Requirement 5 due to combining multiple content formats in a way that traps users inside one format type"
+                  }
+                ]
               }
             },
             {
@@ -1152,8 +3077,12 @@
               ],
               "level": "AAA",
               "details": [],
-              "techniquesHtml": {
-                "sufficient": "<p>No additional techniques exist for this success criterion. Follow \n            <a href=\"keyboard#techniques\" class=\"understanding\">techniques for Success Criterion 2.1.1</a>. If that is not possible because there is a requirement for path-dependent input,\n            then it is not possible to meet this Level AAA success criterion.\n         </p>"
+              "techniques": {
+                "sufficient": [
+                  {
+                    "title": "No additional techniques exist for this success criterion. Follow <a href=\"https://www.w3.org/WAI/WCAG22/Understanding/keyboard#techniques\">techniques for Success Criterion 2.1.1</a>. If that is not possible because there is a requirement for path-dependent input, then it is not possible to meet this Level AAA success criterion."
+                  }
+                ]
               }
             },
             {
@@ -1186,9 +3115,21 @@
                   ]
                 }
               ],
-              "techniquesHtml": {
-                "sufficient": "<ul>\n\t\t\t\t\t\t<li><a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G217\">G217: Providing a mechanism to allow users to remap or turn off character key shortcuts</a></li>\n\t\t\t\t\t</ul>",
-                "failure": "<ul>\n\t\t\t\t\t<li><a href=\"https://www.w3.org/WAI/WCAG22/Techniques/failures/F99\">F99: Failure of Success Criterion 2.1.4 due to implementing character key shortcuts that cannot be turned off or remapped</a></li>\n\t\t\t\t</ul>"
+              "techniques": {
+                "sufficient": [
+                  {
+                    "id": "G217",
+                    "technology": "general",
+                    "title": "Providing a mechanism to allow users to remap or turn off character key shortcuts"
+                  }
+                ],
+                "failure": [
+                  {
+                    "id": "F99",
+                    "technology": "failures",
+                    "title": "Failure of Success Criterion 2.1.4 due to implementing character key shortcuts that cannot be turned off or remapped"
+                  }
+                ]
               }
             }
           ]
@@ -1257,22 +3198,95 @@
                   "text": "This success criterion helps ensure that users can complete tasks without unexpected changes in content or context that are a result of a time limit. This success criterion should be considered in conjunction with Success Criterion 3.2.1, which puts limits on changes of content or context as a result of user action."
                 }
               ],
-              "techniquesHtml": {
+              "techniques": {
                 "sufficient": [
                   {
                     "title": "Situation A: If there are session time limits:",
-                    "content": "<ul>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G133\">G133: Providing a checkbox on the first page of a multipart form that allows users to ask for longer session time limit or no session time limit</a>\n               </li>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G198\">G198: Providing a way for the user to turn the time limit off</a>\n               </li>\n            </ul>"
+                    "techniques": [
+                      {
+                        "id": "G133",
+                        "technology": "general",
+                        "title": "Providing a checkbox on the first page of a multipart form that allows users to ask for longer session time limit or no session time limit"
+                      },
+                      {
+                        "id": "G198",
+                        "technology": "general",
+                        "title": "Providing a way for the user to turn the time limit off"
+                      }
+                    ]
                   },
                   {
                     "title": "Situation B: If a time limit is controlled by a script on the page:",
-                    "content": "<ul>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G198\">G198: Providing a way for the user to turn the time limit off</a>\n               </li>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G180\">G180: Providing the user with a means to set the time limit to 10 times the default time limit</a>\n               </li>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/client-side-script/SCR16\">SCR16: Providing a script that warns the user a time limit is about to expire</a>\n                  <strong>AND</strong>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/client-side-script/SCR1\">SCR1: Allowing the user to extend the default time limit</a>\n               </li>\n            </ul>"
+                    "techniques": [
+                      {
+                        "id": "G198",
+                        "technology": "general",
+                        "title": "Providing a way for the user to turn the time limit off"
+                      },
+                      {
+                        "id": "G180",
+                        "technology": "general",
+                        "title": "Providing the user with a means to set the time limit to 10 times the default time limit"
+                      },
+                      {
+                        "and": [
+                          {
+                            "id": "SCR16",
+                            "technology": "client-side-script",
+                            "title": "Providing a script that warns the user a time limit is about to expire"
+                          },
+                          {
+                            "id": "SCR1",
+                            "technology": "client-side-script",
+                            "title": "Allowing the user to extend the default time limit"
+                          }
+                        ]
+                      }
+                    ]
                   },
                   {
                     "title": "Situation C: If there are time limits on reading:",
-                    "content": "<ul>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G4\">G4: Allowing the content to be paused and restarted from where it was paused</a>\n               </li>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G198\">G198: Providing a way for the user to turn the time limit off</a>\n               </li>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/client-side-script/SCR33\">SCR33: Using script to scroll content, and providing a mechanism to pause it</a>\n               </li>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/client-side-script/SCR36\">SCR36: Providing a mechanism to allow users to display moving, scrolling, or auto-updating text in a static window or area</a>\n               </li>\n            </ul>"
+                    "techniques": [
+                      {
+                        "id": "G4",
+                        "technology": "general",
+                        "title": "Allowing the content to be paused and restarted from where it was paused"
+                      },
+                      {
+                        "id": "G198",
+                        "technology": "general",
+                        "title": "Providing a way for the user to turn the time limit off"
+                      },
+                      {
+                        "id": "SCR33",
+                        "technology": "client-side-script",
+                        "title": "Using script to scroll content, and providing a mechanism to pause it"
+                      },
+                      {
+                        "id": "SCR36",
+                        "technology": "client-side-script",
+                        "title": "Providing a mechanism to allow users to display moving, scrolling, or auto-updating text in a static window or area"
+                      }
+                    ]
                   }
                 ],
-                "failure": "<ul>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/failures/F40\">F40: Failure due to using meta redirect with a time limit </a>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/failures/F41\">F41: Failure of Success Criterion 2.2.1, 2.2.4, and 3.2.5 due to using meta refresh to reload the page</a>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/failures/F58\">F58: Failure of Success Criterion 2.2.1 due to using server-side techniques to automatically redirect pages after a time-out</a>\n            </li>\n         </ul>"
+                "failure": [
+                  {
+                    "id": "F40",
+                    "technology": "failures",
+                    "title": "Failure due to using meta redirect with a time limit"
+                  },
+                  {
+                    "id": "F41",
+                    "technology": "failures",
+                    "title": "Failure of Success Criterion 2.2.1, 2.2.4, and 3.2.5 due to using meta refresh to reload the page"
+                  },
+                  {
+                    "id": "F58",
+                    "technology": "failures",
+                    "title": "Failure of Success Criterion 2.2.1 due to using server-side techniques to automatically redirect pages after a time-out"
+                  }
+                ]
               }
             },
             {
@@ -1324,9 +3338,66 @@
                   "text": "An animation that occurs as part of a preload phase or similar situation can be considered essential if interaction cannot occur during that phase for all users and if not indicating progress could confuse users or cause them to think that content was frozen or broken."
                 }
               ],
-              "techniquesHtml": {
-                "sufficient": "<ul>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G4\">G4: Allowing the content to be paused and restarted from where it was paused</a>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/client-side-script/SCR33\">SCR33: Using script to scroll content, and providing a mechanism to pause it</a>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G11\">G11: Creating content that blinks for less than 5 seconds</a>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G152\">G152: Setting animated gif images to stop blinking after n cycles (within 5 seconds)</a>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/client-side-script/SCR22\">SCR22: Using scripts to control blinking and stop it in five seconds or less</a>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G186\">G186: Using a control in the web page that stops moving, blinking, or auto-updating content</a>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G191\">G191: Providing a link, button, or other mechanism that reloads the page without any blinking content</a>\n            </li>\n         </ul>",
-                "failure": "<ul>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/failures/F16\">F16: Failure of Success Criterion 2.2.2 due to including scrolling content where movement is not essential to the activity without also including a mechanism to pause and restart the content</a>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/failures/F112\">F112: Failure of Success Criterion 2.2.2 due to using blinking content that lasts for more than five seconds without a mechanism to stop it</a>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/failures/F50\">F50: Failure of Success Criterion 2.2.2 due to a script that causes a blink effect without a mechanism to stop the blinking at 5 seconds or less</a>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/failures/F7\">F7: Failure of Success Criterion 2.2.2 due to an object or applet that has blinking content without a mechanism to pause the content that blinks for more than five seconds</a>\n            </li>\n         </ul>"
+              "techniques": {
+                "sufficient": [
+                  {
+                    "id": "G4",
+                    "technology": "general",
+                    "title": "Allowing the content to be paused and restarted from where it was paused"
+                  },
+                  {
+                    "id": "SCR33",
+                    "technology": "client-side-script",
+                    "title": "Using script to scroll content, and providing a mechanism to pause it"
+                  },
+                  {
+                    "id": "G11",
+                    "technology": "general",
+                    "title": "Creating content that blinks for less than 5 seconds"
+                  },
+                  {
+                    "id": "G152",
+                    "technology": "general",
+                    "title": "Setting animated gif images to stop blinking after n cycles (within 5 seconds)"
+                  },
+                  {
+                    "id": "SCR22",
+                    "technology": "client-side-script",
+                    "title": "Using scripts to control blinking and stop it in five seconds or less"
+                  },
+                  {
+                    "id": "G186",
+                    "technology": "general",
+                    "title": "Using a control in the web page that stops moving, blinking, or auto-updating content"
+                  },
+                  {
+                    "id": "G191",
+                    "technology": "general",
+                    "title": "Providing a link, button, or other mechanism that reloads the page without any blinking content"
+                  }
+                ],
+                "failure": [
+                  {
+                    "id": "F16",
+                    "technology": "failures",
+                    "title": "Failure of Success Criterion 2.2.2 due to including scrolling content where movement is not essential to the activity without also including a mechanism to pause and restart the content"
+                  },
+                  {
+                    "id": "F112",
+                    "technology": "failures",
+                    "title": "Failure of Success Criterion 2.2.2 due to using blinking content that lasts for more than five seconds without a mechanism to stop it"
+                  },
+                  {
+                    "id": "F50",
+                    "technology": "failures",
+                    "title": "Failure of Success Criterion 2.2.2 due to a script that causes a blink effect without a mechanism to stop the blinking at 5 seconds or less"
+                  },
+                  {
+                    "id": "F7",
+                    "technology": "failures",
+                    "title": "Failure of Success Criterion 2.2.2 due to an object or applet that has blinking content without a mechanism to pause the content that blinks for more than five seconds"
+                  }
+                ]
               }
             },
             {
@@ -1344,8 +3415,14 @@
               ],
               "level": "AAA",
               "details": [],
-              "techniquesHtml": {
-                "sufficient": "<ul>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G5\">G5: Allowing users to complete an activity without any time limit</a>\n            </li>\n         </ul>"
+              "techniques": {
+                "sufficient": [
+                  {
+                    "id": "G5",
+                    "technology": "general",
+                    "title": "Allowing users to complete an activity without any time limit"
+                  }
+                ]
               }
             },
             {
@@ -1363,9 +3440,36 @@
               ],
               "level": "AAA",
               "details": [],
-              "techniquesHtml": {
-                "sufficient": "<ul>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G75\">G75: Providing a mechanism to postpone any updating of content</a>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G76\">G76: Providing a mechanism to request an update of the content instead of updating automatically</a>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/client-side-script/SCR14\">SCR14: Using scripts to make nonessential alerts optional</a>\n            </li>\n         </ul>",
-                "failure": "<ul>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/failures/F40\">F40: Failure due to using meta redirect with a time limit </a>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/failures/F41\">F41: Failure of Success Criterion 2.2.1, 2.2.4, and 3.2.5 due to using meta refresh to reload the page</a>\n            </li>\n         </ul>"
+              "techniques": {
+                "sufficient": [
+                  {
+                    "id": "G75",
+                    "technology": "general",
+                    "title": "Providing a mechanism to postpone any updating of content"
+                  },
+                  {
+                    "id": "G76",
+                    "technology": "general",
+                    "title": "Providing a mechanism to request an update of the content instead of updating automatically"
+                  },
+                  {
+                    "id": "SCR14",
+                    "technology": "client-side-script",
+                    "title": "Using scripts to make nonessential alerts optional"
+                  }
+                ],
+                "failure": [
+                  {
+                    "id": "F40",
+                    "technology": "failures",
+                    "title": "Failure due to using meta redirect with a time limit"
+                  },
+                  {
+                    "id": "F41",
+                    "technology": "failures",
+                    "title": "Failure of Success Criterion 2.2.1, 2.2.4, and 3.2.5 due to using meta refresh to reload the page"
+                  }
+                ]
               }
             },
             {
@@ -1383,9 +3487,33 @@
               ],
               "level": "AAA",
               "details": [],
-              "techniquesHtml": {
-                "sufficient": "<ul>\n            <li>\n               <p>\n                  Providing options to continue without loss of data using one of the following techniques:\n               </p>\n               <ul>\n                  <li>\n                     <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G105\">G105: Saving data so that it can be used after a user re-authenticates</a>\n                  </li>\n                  <li>\n                     <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G181\">G181: Encoding user data as hidden or encrypted data in a re-authorization page</a>\n                  </li>\n               </ul>\n            </li>\n         </ul>\n         <p class=\"note\">\n\t\t\t\t<em>Note:</em>\n            Refer to \n               Techniques for Addressing Success Criterion 2.2.1 for techniques related to providing notifications about time limits.\n\t\t\t</p>",
-                "failure": "<ul>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/failures/F12\">F12: Failure of Success Criterion 2.2.5 due to having a session time limit without a mechanism for saving user's input and re-establishing that information upon re-authentication</a>\n            </li>\n         </ul>"
+              "techniques": {
+                "sufficient": [
+                  {
+                    "title": "Providing options to continue without loss of data",
+                    "suffix": "using one of the following techniques:",
+                    "using": [
+                      {
+                        "id": "G105",
+                        "technology": "general",
+                        "title": "Saving data so that it can be used after a user re-authenticates"
+                      },
+                      {
+                        "id": "G181",
+                        "technology": "general",
+                        "title": "Encoding user data as hidden or encrypted data in a re-authorization page"
+                      }
+                    ]
+                  }
+                ],
+                "sufficientNote": "Refer to Techniques for Addressing Success Criterion 2.2.1 for techniques related to providing notifications about time limits.",
+                "failure": [
+                  {
+                    "id": "F12",
+                    "technology": "failures",
+                    "title": "Failure of Success Criterion 2.2.5 due to having a session time limit without a mechanism for saving user's input and re-establishing that information upon re-authentication"
+                  }
+                ]
               }
             },
             {
@@ -1406,8 +3534,18 @@
                   "text": "Privacy regulations may require explicit user consent before user identification has been authenticated and before user data is preserved. In cases where the user is a minor, explicit consent may not be solicited in most jurisdictions, countries or regions. Consultation with privacy professionals and legal counsel is advised when considering data preservation as an approach to satisfy this success criterion."
                 }
               ],
-              "techniquesHtml": {
-                "sufficient": "<ul>\n\t\t\t\t\t<li>Setting a session timeout to occur following at least 20 hours of inactivity.</li>\n\t\t\t\t\t<li>Store user data for more than 20 hours.</li>\n\t\t\t\t\t<li>Provide a warning of the duration of user inactivity at the start of a process.</li>\n\t\t\t\t</ul>"
+              "techniques": {
+                "sufficient": [
+                  {
+                    "title": "Setting a session timeout to occur following at least 20 hours of inactivity"
+                  },
+                  {
+                    "title": "Storing user data for more than 20 hours"
+                  },
+                  {
+                    "title": "Providing a warning of the duration of user inactivity at the start of a process"
+                  }
+                ]
               }
             }
           ]
@@ -1445,8 +3583,24 @@
                   "text": "Since any content that does not meet this success criterion can interfere with a user's ability to use the whole page, all content on the web page (whether it is used to meet other success criteria or not) must meet this success criterion. See Conformance Requirement 5: Non-Interference."
                 }
               ],
-              "techniquesHtml": {
-                "sufficient": "<ul>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G19\">G19: Ensuring that no component of the content flashes more than three times in any 1-second period</a>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G176\">G176: Keeping the flashing area small enough</a>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G15\">G15: Using a tool to ensure that content does not violate the general flash threshold or red flash threshold</a>\n            </li>\n         </ul>"
+              "techniques": {
+                "sufficient": [
+                  {
+                    "id": "G19",
+                    "technology": "general",
+                    "title": "Ensuring that no component of the content flashes more than three times in any 1-second period"
+                  },
+                  {
+                    "id": "G176",
+                    "technology": "general",
+                    "title": "Keeping the flashing area small enough"
+                  },
+                  {
+                    "id": "G15",
+                    "technology": "general",
+                    "title": "Using a tool to ensure that content does not violate the general flash threshold or red flash threshold"
+                  }
+                ]
               }
             },
             {
@@ -1464,8 +3618,14 @@
               ],
               "level": "AAA",
               "details": [],
-              "techniquesHtml": {
-                "sufficient": "<ul>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G19\">G19: Ensuring that no component of the content flashes more than three times in any 1-second period</a>\n            </li>\n         </ul>"
+              "techniques": {
+                "sufficient": [
+                  {
+                    "id": "G19",
+                    "technology": "general",
+                    "title": "Ensuring that no component of the content flashes more than three times in any 1-second period"
+                  }
+                ]
               }
             },
             {
@@ -1480,8 +3640,22 @@
               ],
               "level": "AAA",
               "details": [],
-              "techniquesHtml": {
-                "sufficient": "<ul>\n\t\t\t\t\t\t<li><a href=\"https://www.w3.org/WAI/WCAG22/Techniques/css/C39\">C39: Using the CSS reduce-motion query to prevent motion</a></li>\n\t\t\t\t\t\t<li>Gx: Allowing users to set a preference that prevents animation.</li>\n\t\t\t\t\t</ul>"
+              "techniques": {
+                "sufficient": [
+                  {
+                    "id": "C39",
+                    "technology": "css",
+                    "title": "Using the CSS prefers-reduced-motion query to prevent motion"
+                  },
+                  {
+                    "id": "SCR40",
+                    "technology": "client-side-script",
+                    "title": "Using the CSS prefers-reduced-motion query in JavaScript to prevent motion"
+                  },
+                  {
+                    "title": "Gx: Allowing users to set a preference that prevents animation"
+                  }
+                ]
               }
             }
           ]
@@ -1515,9 +3689,73 @@
               ],
               "level": "A",
               "details": [],
-              "techniquesHtml": {
-                "sufficient": "<ul>\n            <li>\n               <p>Creating links to skip blocks of repeated material using one of the following techniques:</p>\n               <ul>\n                  <li>\n                     <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G1\">G1: Adding a link at the top of each page that goes directly to the main content area</a>\n                  </li>\n                  <li>\n                     <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G123\">G123: Adding a link at the beginning of a block of repeated content to go to the end of the block</a>\n                  </li>\n                  <li>\n                     <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G124\">G124: Adding links at the top of the page to each area of the content</a>\n                  </li>\n               </ul>\n            </li>\n            <li>\n               <p>Grouping blocks of repeated material in a way that can be skipped, using one of the\n                  following techniques:\n               </p>\n               <ul>\n                  <li>\n                     <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/aria/ARIA11\">ARIA11: Using ARIA landmarks to identify regions of a page</a>\n                  </li>\n                  <li>\n                     <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/html/H69\">H69: Providing heading elements at the beginning of each section of content</a>\n                  </li>\n                  <li>\n                     <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/pdf/PDF9\">PDF9: Providing headings by marking content with heading tags in PDF documents</a>\n                  </li>\n                  <li>\n                     <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/html/H64\">H64: Using the title attribute of the iframe element</a>\n                  </li>\n                  <li>\n                     <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/client-side-script/SCR28\">SCR28: Using an expandable and collapsible menu to bypass block of content</a>\n                  </li>\n               </ul>\n            </li>\n         </ul>",
-                "advisory": "<ul>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/css/C6\">C6: Positioning content based on structural markup</a>\n            </li>\n         \t<li><a href=\"https://www.w3.org/WAI/WCAG22/Techniques/html/H97\">H97: Grouping related links using the nav element</a></li>\n         </ul>"
+              "techniques": {
+                "sufficient": [
+                  {
+                    "title": "Creating links to skip blocks of repeated material",
+                    "suffix": "using one of the following techniques:",
+                    "using": [
+                      {
+                        "id": "G1",
+                        "technology": "general",
+                        "title": "Adding a link at the top of each page that goes directly to the main content area"
+                      },
+                      {
+                        "id": "G123",
+                        "technology": "general",
+                        "title": "Adding a link at the beginning of a block of repeated content to go to the end of the block"
+                      },
+                      {
+                        "id": "G124",
+                        "technology": "general",
+                        "title": "Adding links at the top of the page to each area of the content"
+                      }
+                    ]
+                  },
+                  {
+                    "title": "Grouping blocks of repeated material in a way that can be skipped",
+                    "suffix": "using one of the following techniques:",
+                    "using": [
+                      {
+                        "id": "ARIA11",
+                        "technology": "aria",
+                        "title": "Using ARIA landmarks to identify regions of a page"
+                      },
+                      {
+                        "id": "H69",
+                        "technology": "html",
+                        "title": "Providing heading elements at the beginning of each section of content"
+                      },
+                      {
+                        "id": "PDF9",
+                        "technology": "pdf",
+                        "title": "Providing headings by marking content with heading tags in PDF documents"
+                      },
+                      {
+                        "id": "H64",
+                        "technology": "html",
+                        "title": "Using the title attribute of the iframe element"
+                      },
+                      {
+                        "id": "SCR28",
+                        "technology": "client-side-script",
+                        "title": "Using an expandable and collapsible menu to bypass block of content"
+                      }
+                    ]
+                  }
+                ],
+                "advisory": [
+                  {
+                    "id": "C6",
+                    "technology": "css",
+                    "title": "Positioning content based on structural markup"
+                  },
+                  {
+                    "id": "H97",
+                    "technology": "html",
+                    "title": "Grouping related links using the nav element"
+                  }
+                ]
               }
             },
             {
@@ -1535,10 +3773,47 @@
               ],
               "level": "A",
               "details": [],
-              "techniquesHtml": {
-                "sufficient": "<ul>\n            <li>\n               <p> \n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G88\">G88: Providing descriptive titles for web pages</a> \n                  <strong>AND</strong> associating a title with a web page using one of the following techniques:\n               </p>\n               <ul>\n                  <li>\n                     <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/html/H25\">H25: Providing a title using the title element</a>\n                  </li>\n                  <li>\n                     <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/pdf/PDF18\">PDF18: Specifying the document title using the Title entry in the document information dictionary of a PDF document</a>\n                  </li>\n               </ul>\n            </li>\n         </ul>",
-                "advisory": "<ul>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G127\">G127: Identifying a web page's relationship to a larger collection of web pages</a>\n            </li>\n         </ul>",
-                "failure": "<ul>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/failures/F25\">F25: Failure of Success Criterion 2.4.2 due to the title of a web page not identifying the contents</a>\n            </li>\n         </ul>"
+              "techniques": {
+                "sufficient": [
+                  {
+                    "and": [
+                      {
+                        "id": "G88",
+                        "technology": "general",
+                        "title": "Providing descriptive titles for web pages"
+                      },
+                      {
+                        "title": "associating a title with a web page"
+                      }
+                    ],
+                    "using": [
+                      {
+                        "id": "H25",
+                        "technology": "html",
+                        "title": "Providing a title using the title element"
+                      },
+                      {
+                        "id": "PDF18",
+                        "technology": "pdf",
+                        "title": "Specifying the document title using the Title entry in the document information dictionary of a PDF document"
+                      }
+                    ]
+                  }
+                ],
+                "advisory": [
+                  {
+                    "id": "G127",
+                    "technology": "general",
+                    "title": "Identifying a web page's relationship to a larger collection of web pages"
+                  }
+                ],
+                "failure": [
+                  {
+                    "id": "F25",
+                    "technology": "failures",
+                    "title": "Failure of Success Criterion 2.4.2 due to the title of a web page not identifying the contents"
+                  }
+                ]
               }
             },
             {
@@ -1556,9 +3831,63 @@
               ],
               "level": "A",
               "details": [],
-              "techniquesHtml": {
-                "sufficient": "<ul>\n            <li>  \t\t\t\t\t\t\t\t\t         \n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G59\">G59: Placing the interactive elements in an order that follows sequences and relationships within the content</a>\n            </li>\n            <li>\n               <p>Giving focus to elements in an order that follows sequences and relationships within the content using one of the following techniques:\n               </p>\n               <ul>\n                  <li>  \t\t\t\t\t\t\t\t\t\t\t             \n                     <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/css/C27\">C27: Making the DOM order match the visual order</a>\t\t\t\t\t\t\t\t\t\t           \n                  </li>\n                  <li>\n                     <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/pdf/PDF3\">PDF3: Ensuring correct tab and reading order in PDF documents</a>\n                  </li>\n               </ul>\n            </li>\n            <li>\n               <p>Changing a web page dynamically using one of the following techniques:</p>\n               <ul>\n                  <li>  \t\t\t\t\t\t\t\t\t\t\t             \n                     <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/client-side-script/SCR26\">SCR26: Inserting dynamic content into the Document Object Model immediately following its trigger element</a>\n                  </li>\n                  <li>\t\t\t\t\t\t\t\t\t\t             \n                     <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/html/H102\">H102: Creating modal dialogs with the HTML dialog element</a>\t\t\t\t\t\t\t\t\t\t           \n                  </li>\n                  <li>\t\t\t\t\t\t\t\t\t\t             \n                     <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/client-side-script/SCR27\">SCR27: Reordering page sections using the Document Object Model</a>\t\t\t\t\t\t\t\t\t\t           \n                  </li>\n               </ul>\n            </li>\n         </ul>",
-                "failure": "<ul>\n            <li>\t\t\t\t\t\t\t\t         \n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/failures/F44\">F44: Failure of Success Criterion 2.4.3 due to using tabindex to create a tab order that does not preserve meaning and operability</a>\n            </li>\n            <li>\t\t\t\t\t\t\t\t         \n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/failures/F85\">F85: Failure of Success Criterion 2.4.3 due to using dialogs or menus that are not adjacent to their trigger control in the sequential navigation order</a>\t\t\t\t       \n            </li>\n         </ul>"
+              "techniques": {
+                "sufficient": [
+                  {
+                    "id": "G59",
+                    "technology": "general",
+                    "title": "Placing the interactive elements in an order that follows sequences and relationships within the content"
+                  },
+                  {
+                    "title": "Giving focus to elements in an order that follows sequences and relationships within the content",
+                    "suffix": "using one of the following techniques:",
+                    "using": [
+                      {
+                        "id": "C27",
+                        "technology": "css",
+                        "title": "Making the DOM order match the visual order"
+                      },
+                      {
+                        "id": "PDF3",
+                        "technology": "pdf",
+                        "title": "Ensuring correct tab and reading order in PDF documents"
+                      }
+                    ]
+                  },
+                  {
+                    "title": "Changing a web page dynamically",
+                    "suffix": "using one of the following techniques:",
+                    "using": [
+                      {
+                        "id": "SCR26",
+                        "technology": "client-side-script",
+                        "title": "Inserting dynamic content into the Document Object Model immediately following its trigger element"
+                      },
+                      {
+                        "id": "H102",
+                        "technology": "html",
+                        "title": "Creating modal dialogs with the HTML dialog element"
+                      },
+                      {
+                        "id": "SCR27",
+                        "technology": "client-side-script",
+                        "title": "Reordering page sections using the Document Object Model"
+                      }
+                    ]
+                  }
+                ],
+                "failure": [
+                  {
+                    "id": "F44",
+                    "technology": "failures",
+                    "title": "Failure of Success Criterion 2.4.3 due to using tabindex to create a tab order that does not preserve meaning and operability"
+                  },
+                  {
+                    "id": "F85",
+                    "technology": "failures",
+                    "title": "Failure of Success Criterion 2.4.3 due to using dialogs or menus that are not adjacent to their trigger control in the sequential navigation order"
+                  }
+                ]
               }
             },
             {
@@ -1576,10 +3905,145 @@
               ],
               "level": "A",
               "details": [],
-              "techniquesHtml": {
-                "sufficient": "<ul>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G91\">G91: Providing link text that describes the purpose of a link</a>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/html/H30\">H30: Providing link text that describes the purpose of a link for anchor elements</a>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/html/H24\">H24: Providing text alternatives for the area elements of image maps</a>\n            </li>\n            <li>\n               <p>Allowing the user to choose short or long link text using one of the techniques below:</p>\n               <ul>\n                  <li>\n                     <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G189\">G189: Providing a control near the beginning of the web page that changes the link text</a>\n                  </li>\n                  <li>\n                     <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/client-side-script/SCR30\">SCR30: Using scripts to change the link text</a>\n                  </li>\n               </ul>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G53\">G53: Identifying the purpose of a link using link text combined with the text of the enclosing sentence</a>\n            </li>\n            <li>\n               <p>Providing a supplemental description of the purpose of a link using one of the following\n                  techniques:\n               </p>\n               <ul>\n                  <li>\n                     <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/html/H33\">H33: Supplementing link text with the title attribute</a>\n                  </li>\n                  <li>\n                     <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/css/C7\">C7: Using CSS to hide a portion of the link text</a>\n                  </li>\n               </ul>\n            </li>\n            <li>\n               <p>\n                  Identifying the purpose of a link using link text combined with programmatically determined\n                  link context using one of the following techniques:\n               </p>\n               <ul>\n                  <li>\n                     <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/aria/ARIA7\">ARIA7: Using aria-labelledby for link purpose</a>\n                  </li>\n                  <li>\n                     <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/aria/ARIA8\">ARIA8: Using aria-label for link purpose</a>\n                  </li>\n                  <li>\n                     <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/html/H77\">H77: Identifying the purpose of a link using link text combined with its enclosing list item</a>\n                  </li>\n                  <li>\n                     <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/html/H78\">H78: Identifying the purpose of a link using link text combined with its enclosing paragraph</a>\n                  </li>\n                  <li>\n                     <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/html/H79\">H79: Identifying the purpose of a link in a data table using the link text combined with its enclosing table cell and associated table header cells</a>\n                  </li>\n                  <li>\n                     <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/html/H81\">H81: Identifying the purpose of a link in a nested list using link text combined with the parent list item under which the list is nested</a>\n                  </li>\n               </ul>\n            </li>\n            <li>\n               <p>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G91\">G91: Providing link text that describes the purpose of a link</a> \n                  <strong>AND</strong> Semantically indicating links using one of the following techniques:\n               </p>\n               <ul>\n                  <li>\n                     <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/pdf/PDF11\">PDF11: Providing links and link text using the Link annotation and the /Link structure element in PDF documents</a>\n                  </li>\n                  <li>\n                     <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/pdf/PDF13\">PDF13: Providing replacement text using the /Alt entry for links in PDF documents</a>\n                  </li>\n               </ul>\n            </li>\n         </ul>",
-                "advisory": "<ul>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/html/H2\">H2: Combining adjacent image and text links for the same resource</a>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/html/H80\">H80: Identifying the purpose of a link using link text combined with the preceding heading element</a>\n            </li>\n         </ul>",
-                "failure": "<ul>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/failures/F63\">F63: Failure of Success Criterion 2.4.4 due to providing link context only in content that is not related to the link</a>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/failures/F89\">F89: Failure of Success Criteria 2.4.4, 2.4.9 and 4.1.2 due to not providing an accessible name for an image which is the only content in a link</a>\n            </li>\n         </ul>"
+              "techniques": {
+                "sufficient": [
+                  {
+                    "id": "G91",
+                    "technology": "general",
+                    "title": "Providing link text that describes the purpose of a link"
+                  },
+                  {
+                    "id": "H30",
+                    "technology": "html",
+                    "title": "Providing link text that describes the purpose of a link for anchor elements"
+                  },
+                  {
+                    "id": "H24",
+                    "technology": "html",
+                    "title": "Providing text alternatives for the area elements of image maps"
+                  },
+                  {
+                    "title": "Allowing the user to choose short or long link text",
+                    "suffix": "using one of the following techniques:",
+                    "using": [
+                      {
+                        "id": "G189",
+                        "technology": "general",
+                        "title": "Providing a control near the beginning of the web page that changes the link text"
+                      },
+                      {
+                        "id": "SCR30",
+                        "technology": "client-side-script",
+                        "title": "Using scripts to change the link text"
+                      }
+                    ]
+                  },
+                  {
+                    "id": "G53",
+                    "technology": "general",
+                    "title": "Identifying the purpose of a link using link text combined with the text of the enclosing sentence"
+                  },
+                  {
+                    "title": "Providing a supplemental description of the purpose of a link",
+                    "suffix": "using one of the following techniques:",
+                    "using": [
+                      {
+                        "id": "H33",
+                        "technology": "html",
+                        "title": "Supplementing link text with the title attribute"
+                      },
+                      {
+                        "id": "C7",
+                        "technology": "css",
+                        "title": "Using CSS to hide a portion of the link text"
+                      }
+                    ]
+                  },
+                  {
+                    "title": "Identifying the purpose of a link using link text combined with programmatically determined link context",
+                    "suffix": "using one of the following techniques:",
+                    "using": [
+                      {
+                        "id": "ARIA7",
+                        "technology": "aria",
+                        "title": "Using aria-labelledby for link purpose"
+                      },
+                      {
+                        "id": "ARIA8",
+                        "technology": "aria",
+                        "title": "Using aria-label for link purpose"
+                      },
+                      {
+                        "id": "H77",
+                        "technology": "html",
+                        "title": "Identifying the purpose of a link using link text combined with its enclosing list item"
+                      },
+                      {
+                        "id": "H78",
+                        "technology": "html",
+                        "title": "Identifying the purpose of a link using link text combined with its enclosing paragraph"
+                      },
+                      {
+                        "id": "H79",
+                        "technology": "html",
+                        "title": "Identifying the purpose of a link in a data table using the link text combined with its enclosing table cell and associated table header cells"
+                      },
+                      {
+                        "id": "H81",
+                        "technology": "html",
+                        "title": "Identifying the purpose of a link in a nested list using link text combined with the parent list item under which the list is nested"
+                      }
+                    ]
+                  },
+                  {
+                    "and": [
+                      {
+                        "id": "G91",
+                        "technology": "general",
+                        "title": "Providing link text that describes the purpose of a link"
+                      },
+                      {
+                        "title": "semantically indicating links"
+                      }
+                    ],
+                    "using": [
+                      {
+                        "id": "PDF11",
+                        "technology": "pdf",
+                        "title": "Providing links and link text using the Link annotation and the /Link structure element in PDF documents"
+                      },
+                      {
+                        "id": "PDF13",
+                        "technology": "pdf",
+                        "title": "Providing replacement text using the /Alt entry for links in PDF documents"
+                      }
+                    ]
+                  }
+                ],
+                "advisory": [
+                  {
+                    "id": "H2",
+                    "technology": "html",
+                    "title": "Combining adjacent image and text links for the same resource"
+                  },
+                  {
+                    "id": "H80",
+                    "technology": "html",
+                    "title": "Identifying the purpose of a link using link text combined with the preceding heading element"
+                  }
+                ],
+                "failure": [
+                  {
+                    "id": "F63",
+                    "technology": "failures",
+                    "title": "Failure of Success Criterion 2.4.4 due to providing link context only in content that is not related to the link"
+                  },
+                  {
+                    "id": "F89",
+                    "technology": "failures",
+                    "title": "Failure of Success Criteria 2.4.4, 2.4.9 and 4.1.2 due to not providing an accessible name for an image which is the only content in a link"
+                  }
+                ]
               }
             },
             {
@@ -1597,9 +4061,51 @@
               ],
               "level": "AA",
               "details": [],
-              "techniquesHtml": {
-                "sufficient": "<ul>\n            <li>\n               <p>Using two or more of the following techniques:</p>\n               <ul>\n                  <li>\n                     <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G125\">G125: Providing links to navigate to related web pages</a>\n                  </li>\n                  <li>\n                     <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G64\">G64: Providing a Table of Contents</a>\n                  </li>\n                  <li>\n                     <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G63\">G63: Providing a site map</a>\n                  </li>\n                  <li>\n                     <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G161\">G161: Providing a search function to help users find content</a>\n                  </li>\n                  <li>\n                     <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G126\">G126: Providing a list of links to all other web pages</a>\n                  </li>\n                  <li>\n                     <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G185\">G185: Linking to all of the pages on the site from the home page</a>\n                  </li>\n               </ul>\n            </li>\n         </ul>",
-                "advisory": "<ul>\n         \t<li>\n         \t\t<a href=\"https://www.w3.org/WAI/WCAG22/Techniques/pdf/PDF2\">PDF2: Creating bookmarks in PDF documents</a>\n         \t</li>\n         </ul>"
+              "techniques": {
+                "sufficient": [
+                  {
+                    "title": "Using two or more of the following techniques:",
+                    "using": [
+                      {
+                        "id": "G125",
+                        "technology": "general",
+                        "title": "Providing links to navigate to related web pages"
+                      },
+                      {
+                        "id": "G64",
+                        "technology": "general",
+                        "title": "Providing a Table of Contents"
+                      },
+                      {
+                        "id": "G63",
+                        "technology": "general",
+                        "title": "Providing a site map"
+                      },
+                      {
+                        "id": "G161",
+                        "technology": "general",
+                        "title": "Providing a search function to help users find content"
+                      },
+                      {
+                        "id": "G126",
+                        "technology": "general",
+                        "title": "Providing a list of links to all other web pages"
+                      },
+                      {
+                        "id": "G185",
+                        "technology": "general",
+                        "title": "Linking to all of the pages on the site from the home page"
+                      }
+                    ]
+                  }
+                ],
+                "advisory": [
+                  {
+                    "id": "PDF2",
+                    "technology": "pdf",
+                    "title": "Creating bookmarks in PDF documents"
+                  }
+                ]
               }
             },
             {
@@ -1617,8 +4123,20 @@
               ],
               "level": "AA",
               "details": [],
-              "techniquesHtml": {
-                "sufficient": "<ul>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G130\">G130: Providing descriptive headings</a>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G131\">G131: Providing descriptive labels</a>\n            </li>\n         </ul>\n         <p class=\"note\">\n\t\t\t\t<em>Note:</em>\n               Headings and labels must be programmatically determined, per \n               Success Criterion 1.3.1.\n\t\t\t</p>"
+              "techniques": {
+                "sufficient": [
+                  {
+                    "id": "G130",
+                    "technology": "general",
+                    "title": "Providing descriptive headings"
+                  },
+                  {
+                    "id": "G131",
+                    "technology": "general",
+                    "title": "Providing descriptive labels"
+                  }
+                ],
+                "sufficientNote": "Headings and labels must be programmatically determined, per Success Criterion 1.3.1."
               }
             },
             {
@@ -1636,9 +4154,56 @@
               ],
               "level": "AA",
               "details": [],
-              "techniquesHtml": {
-                "sufficient": "<ul>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G149\">G149: Using user interface components that are highlighted by the user agent when they receive focus</a>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/css/C15\">C15: Using CSS to change the presentation of a user interface component when it receives focus</a>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G165\">G165: Using the default focus indicator for the platform so that high visibility default focus indicators will carry over</a>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G195\">G195: Using an author-supplied, visible focus indicator</a>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/css/C40\">C40: Creating a two-color focus indicator to ensure sufficient contrast with all components</a>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/css/C45\">C45: Using CSS :focus-visible to provide keyboard focus indication</a>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/client-side-script/SCR31\">SCR31: Using script to change the background color or border of the element with focus</a>\n            </li>\n         </ul>",
-                "failure": "<ul>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/failures/F55\">F55: Failure of Success Criteria 2.1.1, 2.4.7, 2.4.13, and 3.2.1 due to using script to remove focus when focus is received</a>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/failures/F78\">F78: Failure of Success Criterion 1.4.11, 2.4.7 and 2.4.13 due to styling element outlines and borders in a way that removes or renders non-visible the visual focus indicator</a>\n            </li>\n         </ul>"
+              "techniques": {
+                "sufficient": [
+                  {
+                    "id": "G149",
+                    "technology": "general",
+                    "title": "Using user interface components that are highlighted by the user agent when they receive focus"
+                  },
+                  {
+                    "id": "C15",
+                    "technology": "css",
+                    "title": "Using CSS to change the presentation of a user interface component when it receives focus"
+                  },
+                  {
+                    "id": "G165",
+                    "technology": "general",
+                    "title": "Using the default focus indicator for the platform so that high visibility default focus indicators will carry over"
+                  },
+                  {
+                    "id": "G195",
+                    "technology": "general",
+                    "title": "Using an author-supplied, visible focus indicator"
+                  },
+                  {
+                    "id": "C40",
+                    "technology": "css",
+                    "title": "Creating a two-color focus indicator to ensure sufficient contrast with all components"
+                  },
+                  {
+                    "id": "C45",
+                    "technology": "css",
+                    "title": "Using CSS :focus-visible to provide keyboard focus indication"
+                  },
+                  {
+                    "id": "SCR31",
+                    "technology": "client-side-script",
+                    "title": "Using script to change the background color or border of the element with focus"
+                  }
+                ],
+                "failure": [
+                  {
+                    "id": "F55",
+                    "technology": "failures",
+                    "title": "Failure of Success Criteria 2.1.1, 2.4.7, 2.4.13, and 3.2.1 due to using script to remove focus when focus is received"
+                  },
+                  {
+                    "id": "F78",
+                    "technology": "failures",
+                    "title": "Failure of Success Criterion 1.4.11, 2.4.7 and 2.4.13 due to styling element outlines and borders in a way that removes or renders non-visible the visual focus indicator"
+                  }
+                ]
               }
             },
             {
@@ -1656,9 +4221,41 @@
               ],
               "level": "AAA",
               "details": [],
-              "techniquesHtml": {
-                "sufficient": "<ul>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G65\">G65: Providing a breadcrumb trail</a>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G63\">G63: Providing a site map</a>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G128\">G128: Indicating current location within navigation bars</a>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G127\">G127: Identifying a web page's relationship to a larger collection of web pages</a>\n            </li>\n         </ul>",
-                "advisory": "<ul>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/pdf/PDF14\">PDF14: Providing running headers and footers in PDF documents</a>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/pdf/PDF17\">PDF17: Specifying consistent page numbering for PDF documents</a>\n            </li>\n         </ul>"
+              "techniques": {
+                "sufficient": [
+                  {
+                    "id": "G65",
+                    "technology": "general",
+                    "title": "Providing a breadcrumb trail"
+                  },
+                  {
+                    "id": "G63",
+                    "technology": "general",
+                    "title": "Providing a site map"
+                  },
+                  {
+                    "id": "G128",
+                    "technology": "general",
+                    "title": "Indicating current location within navigation bars"
+                  },
+                  {
+                    "id": "G127",
+                    "technology": "general",
+                    "title": "Identifying a web page's relationship to a larger collection of web pages"
+                  }
+                ],
+                "advisory": [
+                  {
+                    "id": "PDF14",
+                    "technology": "pdf",
+                    "title": "Providing running headers and footers in PDF documents"
+                  },
+                  {
+                    "id": "PDF17",
+                    "technology": "pdf",
+                    "title": "Specifying consistent page numbering for PDF documents"
+                  }
+                ]
               }
             },
             {
@@ -1676,10 +4273,96 @@
               ],
               "level": "AAA",
               "details": [],
-              "techniquesHtml": {
-                "sufficient": "<ul>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/aria/ARIA8\">ARIA8: Using aria-label for link purpose</a>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G91\">G91: Providing link text that describes the purpose of a link</a>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/html/H30\">H30: Providing link text that describes the purpose of a link for anchor elements</a>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/html/H24\">H24: Providing text alternatives for the area elements of image maps</a>\n            </li>\n            <li>\n               <p>Allowing the user to choose short or long link text using one of the techniques below:</p>\n               <ul>\n                  <li>\n                     <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G189\">G189: Providing a control near the beginning of the web page that changes the link text</a>\n                  </li>\n                  <li>\n                     <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/client-side-script/SCR30\">SCR30: Using scripts to change the link text</a>\n                  </li>\n               </ul>\n            </li>\n            <li>\n               <p>Providing a supplemental description of the purpose of a link using one of the following\n                  techniques:    \n               </p>\n               <ul>\n                  <li>\n                     <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/css/C7\">C7: Using CSS to hide a portion of the link text</a>\n                  </li>\n               </ul>\n            </li>\n            <li>\n               <p>Semantically indicating links using one of the following techniques:</p>\n               <ul>\n                  <li>\n                     <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/pdf/PDF11\">PDF11: Providing links and link text using the Link annotation and the /Link structure element in PDF documents</a>\n                  </li>\n                  <li>\n                     <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/pdf/PDF13\">PDF13: Providing replacement text using the /Alt entry for links in PDF documents</a>\n                  </li>\n               </ul>\n            </li>\n         </ul>",
-                "advisory": "<ul>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/html/H2\">H2: Combining adjacent image and text links for the same resource</a>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/html/H33\">H33: Supplementing link text with the title attribute</a>\n            </li>\n         </ul>",
-                "failure": "<ul>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/failures/F84\">F84: Failure of Success Criterion 2.4.9 due to using a non-specific link such as \"click here\" or \"more\" without a mechanism to change the link text to specific text.</a>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/failures/F89\">F89: Failure of Success Criteria 2.4.4, 2.4.9 and 4.1.2 due to not providing an accessible name for an image which is the only content in a link</a>\n            </li>\n         </ul>"
+              "techniques": {
+                "sufficient": [
+                  {
+                    "id": "ARIA8",
+                    "technology": "aria",
+                    "title": "Using aria-label for link purpose"
+                  },
+                  {
+                    "id": "G91",
+                    "technology": "general",
+                    "title": "Providing link text that describes the purpose of a link"
+                  },
+                  {
+                    "id": "H30",
+                    "technology": "html",
+                    "title": "Providing link text that describes the purpose of a link for anchor elements"
+                  },
+                  {
+                    "id": "H24",
+                    "technology": "html",
+                    "title": "Providing text alternatives for the area elements of image maps"
+                  },
+                  {
+                    "title": "Allowing the user to choose short or long link text",
+                    "suffix": "using one of the following techniques:",
+                    "using": [
+                      {
+                        "id": "G189",
+                        "technology": "general",
+                        "title": "Providing a control near the beginning of the web page that changes the link text"
+                      },
+                      {
+                        "id": "SCR30",
+                        "technology": "client-side-script",
+                        "title": "Using scripts to change the link text"
+                      }
+                    ]
+                  },
+                  {
+                    "title": "Providing a supplemental description of the purpose of a link",
+                    "suffix": "using one of the following techniques:",
+                    "using": [
+                      {
+                        "id": "C7",
+                        "technology": "css",
+                        "title": "Using CSS to hide a portion of the link text"
+                      }
+                    ]
+                  },
+                  {
+                    "title": "Semantically indicating links",
+                    "suffix": "using one of the following techniques:",
+                    "using": [
+                      {
+                        "id": "PDF11",
+                        "technology": "pdf",
+                        "title": "Providing links and link text using the Link annotation and the /Link structure element in PDF documents"
+                      },
+                      {
+                        "id": "PDF13",
+                        "technology": "pdf",
+                        "title": "Providing replacement text using the /Alt entry for links in PDF documents"
+                      }
+                    ]
+                  }
+                ],
+                "advisory": [
+                  {
+                    "id": "H2",
+                    "technology": "html",
+                    "title": "Combining adjacent image and text links for the same resource"
+                  },
+                  {
+                    "id": "H33",
+                    "technology": "html",
+                    "title": "Supplementing link text with the title attribute"
+                  }
+                ],
+                "failure": [
+                  {
+                    "id": "F84",
+                    "technology": "failures",
+                    "title": "Failure of Success Criterion 2.4.9 due to using a non-specific link such as \"click here\" or \"more\" without a mechanism to change the link text to specific text."
+                  },
+                  {
+                    "id": "F89",
+                    "technology": "failures",
+                    "title": "Failure of Success Criteria 2.4.4, 2.4.9 and 4.1.2 due to not providing an accessible name for an image which is the only content in a link"
+                  }
+                ]
               }
             },
             {
@@ -1708,8 +4391,19 @@
                   "text": "This success criterion covers sections within writing, not user interface components. User interface components are covered under Success Criterion 4.1.2."
                 }
               ],
-              "techniquesHtml": {
-                "sufficient": "<ul>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G141\">G141: Organizing a page using headings</a>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/html/H69\">H69: Providing heading elements at the beginning of each section of content</a>\n            </li>\n         </ul>"
+              "techniques": {
+                "sufficient": [
+                  {
+                    "id": "G141",
+                    "technology": "general",
+                    "title": "Organizing a page using headings"
+                  },
+                  {
+                    "id": "H69",
+                    "technology": "html",
+                    "title": "Providing heading elements at the beginning of each section of content"
+                  }
+                ]
               }
             },
             {
@@ -1734,9 +4428,21 @@
                   "text": "Content opened by the <em>user</em> may obscure the component receiving focus. If the user can reveal the focused component without advancing the keyboard focus, the component with focus is not considered visually hidden due to author-created content."
                 }
               ],
-              "techniquesHtml": {
-                "sufficient": "<ul>\n            <li>\n              <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/css/C43\">C43: Using CSS scroll-padding to un-obscure content</a>\n            </li>\n         </ul>",
-                "failure": "<ul>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/failures/F110\">F110: Failure of Success Criterion 2.4.11 Focus Not Obscured (Minimum) due to a sticky footer or header completely hiding focused elements</a>\n            </li>\n         </ul>"
+              "techniques": {
+                "sufficient": [
+                  {
+                    "id": "C43",
+                    "technology": "css",
+                    "title": "Using CSS scroll-padding to un-obscure content"
+                  }
+                ],
+                "failure": [
+                  {
+                    "id": "F110",
+                    "technology": "failures",
+                    "title": "Failure of Success Criterion 2.4.11 Focus Not Obscured (Minimum) due to a sticky footer or header completely hiding focused elements"
+                  }
+                ]
               }
             },
             {
@@ -1750,9 +4456,22 @@
               ],
               "level": "AAA",
               "details": [],
-              "techniquesHtml": {
-                "sufficient": "<ul>\n      <li> <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/css/C43\">C43: Using CSS scroll-padding to un-obscure content</a></li>\n    </ul>",
-                "failure": "<ul>\n      <li>An interaction that causes content to appear over the component with keyboard focus, visually covering part of the focus indicator. This behavior might be encountered with advertising or promotional material meant to provide more information about a product as the user navigates through a catalogue.</li>\n      <li>A page has a sticky footer (attached to the bottom of the viewport). When tabbing down the page, a focused item is partially obscured by the footer because content in the viewport scrolls without sufficient <a href=\"https://www.w3.org/TR/css-scroll-snap/#propdef-scroll-padding\" rel=\"nofollow\">scroll padding</a>.</li>\n    </ul>"
+              "techniques": {
+                "sufficient": [
+                  {
+                    "id": "C43",
+                    "technology": "css",
+                    "title": "Using CSS scroll-padding to un-obscure content"
+                  }
+                ],
+                "failure": [
+                  {
+                    "title": "An interaction that causes content to appear over the component with keyboard focus, visually covering part of the focus indicator. This behavior might be encountered with advertising or promotional material meant to provide more information about a product as the user navigates through a catalogue."
+                  },
+                  {
+                    "title": "A page has a sticky footer (attached to the bottom of the viewport). When tabbing down the page, a focused item is partially obscured by the footer because content in the viewport scrolls without sufficient <a href=\"https://www.w3.org/TR/css-scroll-snap/#propdef-scroll-padding\" rel=\"nofollow\">scroll padding</a>."
+                  }
+                ]
               }
             },
             {
@@ -1808,9 +4527,36 @@
                   "text": "Contrast calculations can be based on colors defined within the technology (such as <abbr title=\"HyperText Markup Language\">HTML</abbr>, CSS, and SVG). Pixels modified by user agent resolution enhancements and anti-aliasing can be ignored."
                 }
               ],
-              "techniquesHtml": {
-                "sufficient": "<ul>\n                <li>\n                    <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G195\">G195: Using an author-supplied, visible focus indicator</a>\n                </li>\n                <li>\n                    <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/css/C40\">C40: Creating a two-color focus indicator to ensure sufficient contrast with all components</a>\n                </li>\n                <li>\n                    <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/css/C41\">C41: Creating a strong focus indicator within the component</a>\n                </li>\n            </ul>",
-                "failure": "<ul>\n                <li>\n                    <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/failures/F55\">F55: Failure of Success Criteria 2.1.1, 2.4.7, 2.4.13, and 3.2.1 due to using script to remove focus when focus is received</a>\n                </li>\n                <li>\n                    <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/failures/F78\">F78: Failure of Success Criterion 1.4.11, 2.4.7 and 2.4.13 due to styling element outlines and borders in a way that removes or renders non-visible the visual focus indicator</a>\n                </li>\n            </ul>"
+              "techniques": {
+                "sufficient": [
+                  {
+                    "id": "G195",
+                    "technology": "general",
+                    "title": "Using an author-supplied, visible focus indicator"
+                  },
+                  {
+                    "id": "C40",
+                    "technology": "css",
+                    "title": "Creating a two-color focus indicator to ensure sufficient contrast with all components"
+                  },
+                  {
+                    "id": "C41",
+                    "technology": "css",
+                    "title": "Creating a strong focus indicator within the component"
+                  }
+                ],
+                "failure": [
+                  {
+                    "id": "F55",
+                    "technology": "failures",
+                    "title": "Failure of Success Criteria 2.1.1, 2.4.7, 2.4.13, and 3.2.1 due to using script to remove focus when focus is received"
+                  },
+                  {
+                    "id": "F78",
+                    "technology": "failures",
+                    "title": "Failure of Success Criterion 1.4.11, 2.4.7 and 2.4.13 due to styling element outlines and borders in a way that removes or renders non-visible the visual focus indicator"
+                  }
+                ]
               }
             }
           ]
@@ -1844,9 +4590,26 @@
                   "text": "This requirement applies to web content that interprets pointer actions (i.e., this does not apply to actions that are required to operate the user agent or assistive technology)."
                 }
               ],
-              "techniquesHtml": {
-                "sufficient": "<ul>\n\t\t\t\t\t<li><a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G215\">G215: Providing controls to achieve the same result as path based or multipoint gestures</a></li>\n\t\t\t\t\t<li><a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G216\">G216: Providing single point activation for a control slider</a></li>\n\t\t\t\t</ul>",
-                "failure": "<ul>\n\t\t\t\t\t<li><a href=\"https://www.w3.org/WAI/WCAG22/Techniques/failures/F105\">F105: Failure of Success Criterion 2.5.1 due to providing functionality via a path-based gesture without simple pointer alternative</a></li>\n\t\t\t\t</ul>"
+              "techniques": {
+                "sufficient": [
+                  {
+                    "id": "G215",
+                    "technology": "general",
+                    "title": "Providing controls to achieve the same result as path based or multipoint gestures"
+                  },
+                  {
+                    "id": "G216",
+                    "technology": "general",
+                    "title": "Providing single point activation for a control slider"
+                  }
+                ],
+                "failure": [
+                  {
+                    "id": "F105",
+                    "technology": "failures",
+                    "title": "Failure of Success Criterion 2.5.1 due to providing functionality via a path-based gesture without simple pointer alternative"
+                  }
+                ]
               }
             },
             {
@@ -1893,9 +4656,29 @@
                   "text": "This requirement applies to web content that interprets pointer actions (i.e., this does not apply to actions that are required to operate the user agent or assistive technology)."
                 }
               ],
-              "techniquesHtml": {
-                "sufficient": "<ul>\n\t\t\t\t\t\t<li><a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G210\">G210: Ensuring that drag-and-drop actions can be cancelled</a></li>\n\t\t\t\t\t\t<li><a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G212\">G212: Using native controls to ensure  functionality is triggered on the up-event.</a></li>\n\t\t\t\t\t\t<li>Touch events are only triggered when touch is removed from a control (Potential future technique)</li>\t\t\n\t\t\t\t\t</ul>",
-                "failure": "<ul>\n\t\t\t\t\t<li><a href=\"https://www.w3.org/WAI/WCAG22/Techniques/failures/F101\">F101: Failure of Success Criterion 2.5.2 due to activating a control on the down-event</a></li>\n\t\t\t\t</ul>"
+              "techniques": {
+                "sufficient": [
+                  {
+                    "id": "G210",
+                    "technology": "general",
+                    "title": "Ensuring that drag-and-drop actions can be cancelled"
+                  },
+                  {
+                    "id": "G212",
+                    "technology": "general",
+                    "title": "Using native controls to ensure  functionality is triggered on the up-event."
+                  },
+                  {
+                    "title": "Touch events are only triggered when touch is removed from a control (Potential future technique)"
+                  }
+                ],
+                "failure": [
+                  {
+                    "id": "F101",
+                    "technology": "failures",
+                    "title": "Failure of Success Criterion 2.5.2 due to activating a control on the down-event"
+                  }
+                ]
               }
             },
             {
@@ -1916,10 +4699,47 @@
                   "text": "A best practice is to have  the text of the label at the start of the name."
                 }
               ],
-              "techniquesHtml": {
-                "sufficient": "<ul>\n\t\t\t\t\t<li><a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G208\">G208: Including the text of the visible label as part of the accessible name</a></li>\n\t\t\t\t\t<li><a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G211\">G211: Matching the accessible name to the visible label</a></li>\n\t\t\t\t</ul>",
-                "advisory": "<ul>\n\t\t\t\t\t<li><a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G162\">G162: Positioning labels to maximize predictability of relationships</a></li>\n\t\t\t\t\t<li>If an icon has no accompanying text, consider using its hover text as its accessible name (Potential future technique)</li>\n\t\t\t\t</ul>",
-                "failure": "<ul>\n\t\t\t\t\t<li><a href=\"https://www.w3.org/WAI/WCAG22/Techniques/failures/F96\">F96: Failure due to the accessible name not containing the visible label text</a></li>\n\t\t\t\t\t<li><a href=\"https://www.w3.org/WAI/WCAG22/Techniques/failures/F111\">F111: Failure of Success Criteria 1.3.1, 2.5.3, and 4.1.2 due to a control with visible label text but no accessible name</a></li>\n\t\t\t\t\t<li>Accessible name contains the visible label text, but the words of the visible label are not in the same order as they are in the visible label text (Potential future technique)</li>\n\t\t\t\t\t<li>Accessible name contains the visible label text, but one or more other words are interspersed in the label (Potential future technique)</li>\n\t\t\t\t</ul>"
+              "techniques": {
+                "sufficient": [
+                  {
+                    "id": "G208",
+                    "technology": "general",
+                    "title": "Including the text of the visible label as part of the accessible name"
+                  },
+                  {
+                    "id": "G211",
+                    "technology": "general",
+                    "title": "Matching the accessible name to the visible label"
+                  }
+                ],
+                "advisory": [
+                  {
+                    "id": "G162",
+                    "technology": "general",
+                    "title": "Positioning labels to maximize predictability of relationships"
+                  },
+                  {
+                    "title": "If an icon has no accompanying text, consider using its hover text as its accessible name (Potential future technique)"
+                  }
+                ],
+                "failure": [
+                  {
+                    "id": "F96",
+                    "technology": "failures",
+                    "title": "Failure due to the accessible name not containing the visible label text"
+                  },
+                  {
+                    "id": "F111",
+                    "technology": "failures",
+                    "title": "Failure of Success Criteria 1.3.1, 2.5.3, and 4.1.2 due to a control with visible label text but no accessible name"
+                  },
+                  {
+                    "title": "Accessible name contains the visible label text, but the words of the visible label are not in the same order as they are in the visible label text (Potential future technique)"
+                  },
+                  {
+                    "title": "Accessible name contains the visible label text, but one or more other words are interspersed in the label (Potential future technique)"
+                  }
+                ]
               }
             },
             {
@@ -1948,9 +4768,27 @@
                   ]
                 }
               ],
-              "techniquesHtml": {
-                "sufficient": "<ul>\n          <li><a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G213\">G213: Provide conventional controls and an application setting for motion activated input</a></li>\n          <li>GXXX: Supporting system level features which allow the user to disable motion actuation</li>\n        </ul>",
-                "failure": "<ul>\n          <li><a href=\"https://www.w3.org/WAI/WCAG22/Techniques/failures/F106\">F106: Failure due to inability to deactivate motion actuation</a></li>\n          <li>FXXX: Failure of Success Criterion 2.5.4 due to disrupting or disabling system level features which allow the user to disable motion actuation</li>\n        </ul>"
+              "techniques": {
+                "sufficient": [
+                  {
+                    "id": "G213",
+                    "technology": "general",
+                    "title": "Provide conventional controls and an application setting for motion activated input"
+                  },
+                  {
+                    "title": "GXXX: Supporting system level features which allow the user to disable motion actuation"
+                  }
+                ],
+                "failure": [
+                  {
+                    "id": "F106",
+                    "technology": "failures",
+                    "title": "Failure due to inability to deactivate motion actuation"
+                  },
+                  {
+                    "title": "FXXX: Failure of Success Criterion 2.5.4 due to disrupting or disabling system level features which allow the user to disable motion actuation"
+                  }
+                ]
               }
             },
             {
@@ -1987,10 +4825,22 @@
                   ]
                 }
               ],
-              "techniquesHtml": {
-                "sufficient": "<section class=\"situation\">\n          <ul>\n            <li>Ensuring that targets are at least 44 by 44 CSS pixels.</li>\n          </ul>\n        </section>",
-                "advisory": "<ul>\n            <li>Ensuring inline links provide sufficiently large activation target.</li>\n        </ul>",
-                "failure": "<ul>\n          <li>Failure of Success Criterion 2.5.5 due to target being less than 44 by 44 CSS pixels.</li>\n        </ul>"
+              "techniques": {
+                "sufficient": [
+                  {
+                    "title": "Ensuring that targets are at least 44 by 44 CSS pixels"
+                  }
+                ],
+                "advisory": [
+                  {
+                    "title": "Ensuring inline links provide sufficiently large activation target"
+                  }
+                ],
+                "failure": [
+                  {
+                    "title": "Failure of Success Criterion 2.5.5 due to target being less than 44 by 44 CSS pixels"
+                  }
+                ]
               }
             },
             {
@@ -2005,9 +4855,22 @@
               ],
               "level": "AAA",
               "details": [],
-              "techniquesHtml": {
-                "sufficient": "<ul>\n          <li>Only using high-level, input-agnostic event handlers, such as <code>focus</code>, <code>blur</code>, <code>click</code>, in Javascript (Potential future technique).</li>\n          <li>Registering event handlers for keyboard/keyboard-like and pointer inputs simultaneously in Javascript; see <a href=\"https://www.w3.org/TR/pointerevents2/#example_1\">Example 1 in Pointer Events Level 2</a> (Potential future technique)</li>\n        </ul>",
-                "failure": "<ul>\n          <li><a href=\"https://www.w3.org/WAI/WCAG22/Techniques/failures/F98\">F98: Failure due to interactions being limited to touch-only on touchscreen devices</a></li>\n        </ul>"
+              "techniques": {
+                "sufficient": [
+                  {
+                    "title": "Only using high-level, input-agnostic event handlers, such as <code>focus</code>, <code>blur</code>, <code>click</code>, in Javascript (Potential future technique)"
+                  },
+                  {
+                    "title": "Registering event handlers for keyboard/keyboard-like and pointer inputs simultaneously in Javascript; see <a href=\"https://www.w3.org/TR/pointerevents2/#example_1\">Example 1 in Pointer Events Level 2</a> (Potential future technique)"
+                  }
+                ],
+                "failure": [
+                  {
+                    "id": "F98",
+                    "technology": "failures",
+                    "title": "Failure due to interactions being limited to touch-only on touchscreen devices"
+                  }
+                ]
               }
             },
             {
@@ -2027,9 +4890,21 @@
                   "text": "This requirement applies to web content that interprets pointer actions (i.e., this does not apply to actions that are required to operate the user agent or assistive technology)."
                 }
               ],
-              "techniquesHtml": {
-                "sufficient": "<ul>\n            <li>\n                <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G219\">G219: Ensuring that an alternative is available for dragging movements that operate on content</a>\n            </li>\n         </ul>",
-                "failure": "<ul>\n            <li>\t\t\t\t\t\t\t\t         \n                <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/failures/F108\">F108: Failure of Success Criterion 2.5.7 Dragging Movements due to not providing a single pointer method that does not require a dragging movement</a>\t\t\t\t\t\t       \n            </li>\n         </ul>"
+              "techniques": {
+                "sufficient": [
+                  {
+                    "id": "G219",
+                    "technology": "general",
+                    "title": "Ensuring that an alternative is available for dragging movements that operate on content"
+                  }
+                ],
+                "failure": [
+                  {
+                    "id": "F108",
+                    "technology": "failures",
+                    "title": "Failure of Success Criterion 2.5.7 Dragging Movements due to not providing a single pointer method that does not require a dragging movement"
+                  }
+                ]
               }
             },
             {
@@ -2079,8 +4954,14 @@
                   "text": "For inline targets the line-height should be interpreted as perpendicular to the flow of text. For example, in a language displayed vertically, the line-height would be horizontal."
                 }
               ],
-              "techniquesHtml": {
-                "sufficient": "<ul>\n                <li>\n                    <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/css/C42\">C42: Using min-height and min-width to ensure sufficient target spacing</a>\n                </li>\n            </ul>"
+              "techniques": {
+                "sufficient": [
+                  {
+                    "id": "C42",
+                    "technology": "css",
+                    "title": "Using min-height and min-width to ensure sufficient target spacing"
+                  }
+                ]
               }
             }
           ]
@@ -2127,9 +5008,31 @@
               ],
               "level": "A",
               "details": [],
-              "techniquesHtml": {
-                "sufficient": "<ul>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/html/H57\">H57: Using the language attribute on the HTML element</a>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/pdf/PDF16\">PDF16: Setting the default language using the /Lang entry in the document catalog of a PDF document</a>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/pdf/PDF19\">PDF19: Specifying the language for a passage or phrase with the Lang entry in PDF documents</a>\n            </li>\n         </ul>",
-                "advisory": "<ul>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/server-side-script/SVR5\">SVR5: Specifying the default language in the HTTP header</a>\n            </li>\n         </ul>"
+              "techniques": {
+                "sufficient": [
+                  {
+                    "id": "H57",
+                    "technology": "html",
+                    "title": "Using the language attribute on the HTML element"
+                  },
+                  {
+                    "id": "PDF16",
+                    "technology": "pdf",
+                    "title": "Setting the default language using the /Lang entry in the document catalog of a PDF document"
+                  },
+                  {
+                    "id": "PDF19",
+                    "technology": "pdf",
+                    "title": "Specifying the language for a passage or phrase with the Lang entry in PDF documents"
+                  }
+                ],
+                "advisory": [
+                  {
+                    "id": "SVR5",
+                    "technology": "server-side-script",
+                    "title": "Specifying the default language in the HTTP header"
+                  }
+                ]
               }
             },
             {
@@ -2147,8 +5050,19 @@
               ],
               "level": "AA",
               "details": [],
-              "techniquesHtml": {
-                "sufficient": "<ul> \n            <li>  \t\t\t\t\t\t\t\t\t         \n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/html/H58\">H58: Using language attributes to identify changes in the human language</a>.\t       \n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/pdf/PDF19\">PDF19: Specifying the language for a passage or phrase with the Lang entry in PDF documents</a>.\n            </li>\n         </ul>"
+              "techniques": {
+                "sufficient": [
+                  {
+                    "id": "H58",
+                    "technology": "html",
+                    "title": "Using language attributes to identify changes in the human language"
+                  },
+                  {
+                    "id": "PDF19",
+                    "technology": "pdf",
+                    "title": "Specifying the language for a passage or phrase with the Lang entry in PDF documents"
+                  }
+                ]
               }
             },
             {
@@ -2166,15 +5080,111 @@
               ],
               "level": "AAA",
               "details": [],
-              "techniquesHtml": {
+              "techniques": {
                 "sufficient": [
                   {
                     "title": "Situation A: If the word or phrase has a unique meaning within the web page:",
-                    "content": "<ul>\n               <li>\n                  <p> \n                     <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G101\">G101: Providing the definition of a word or phrase used in an unusual or restricted way</a> for the first occurrence of the word or phrase in a web page using one of the following\n                     techniques:\n                  </p>\n                  <ul>\n                     <li>\n                        <p>\n                           <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G55\">G55: Linking to definitions</a>\n                        </p>\n                        <ul>\n                           <li>\n                              <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/html/H40\">H40: Using description lists</a>\n                           </li>\n                        </ul>\n                     </li>\n                     <li>\n                        <p>\n                           <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G112\">G112: Using inline definitions</a>\n                        </p>\n                        <ul>\n                           <li>\n                              <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/html/H54\">H54: Using the dfn element to identify the defining instance of a word</a>\n                           </li>\n                        </ul>\n                     </li>\n                  </ul>\n               </li>\n               <li>\n                  <p> \n                     <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G101\">G101: Providing the definition of a word or phrase used in an unusual or restricted way</a> for each occurrence of the word or phrase in a web page using one of the following\n                     techniques:\n                  </p>\n                  <ul>\n                     <li>\n                        <p>\n                           <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G55\">G55: Linking to definitions</a>\n                        </p>\n                        <ul>\n                           <li>\n                              <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/html/H40\">H40: Using description lists</a>\n                           </li>\n                        </ul>\n                     </li>\n                     <li>\n                        <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G62\">G62: Providing a glossary</a>\n                     </li>\n                     <li>\n                        <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G70\">G70: Providing a function to search an online dictionary</a>\n                     </li>\n                  </ul>\n               </li>\n            </ul>"
+                    "techniques": [
+                      {
+                        "id": "G101",
+                        "technology": "general",
+                        "title": "Providing the definition of a word or phrase used in an unusual or restricted way",
+                        "suffix": "for the first occurrence of the word or phrase in a web page using one of the following techniques:",
+                        "using": [
+                          {
+                            "id": "G55",
+                            "technology": "general",
+                            "title": "Linking to definitions",
+                            "using": [
+                              {
+                                "id": "H40",
+                                "technology": "html",
+                                "title": "Using description lists"
+                              }
+                            ]
+                          },
+                          {
+                            "id": "G112",
+                            "technology": "general",
+                            "title": "Using inline definitions",
+                            "using": [
+                              {
+                                "id": "H54",
+                                "technology": "html",
+                                "title": "Using the dfn element to identify the defining instance of a word"
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "id": "G101",
+                        "technology": "general",
+                        "title": "Providing the definition of a word or phrase used in an unusual or restricted way",
+                        "suffix": "for each occurrence of the word or phrase in a web page using one of the following techniques:",
+                        "using": [
+                          {
+                            "id": "G55",
+                            "technology": "general",
+                            "title": "Linking to definitions",
+                            "using": [
+                              {
+                                "id": "H40",
+                                "technology": "html",
+                                "title": "Using description lists"
+                              }
+                            ]
+                          },
+                          {
+                            "id": "G62",
+                            "technology": "general",
+                            "title": "Providing a glossary"
+                          },
+                          {
+                            "id": "G70",
+                            "technology": "general",
+                            "title": "Providing a function to search an online dictionary"
+                          }
+                        ]
+                      }
+                    ]
                   },
                   {
                     "title": "Situation B: If the word or phrase means different things within the same web page:",
-                    "content": "<ul>\n               <li>\n                  <p> \n                     <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G101\">G101: Providing the definition of a word or phrase used in an unusual or restricted way</a> for each occurrence of the word or phrase in a web page using one of the following\n                     techniques:\n                  </p>\n                  <ul>\n                     <li>\n                        <p>\n                           <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G55\">G55: Linking to definitions</a>\n                        </p>\n                        <ul>\n                           <li>\n                              <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/html/H40\">H40: Using description lists</a>\n                           </li>\n                        </ul>\n                     </li>\n                     <li>\n                        <p>\n                           <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G112\">G112: Using inline definitions</a>\n                        </p>\n                        <ul>\n                           <li>\n                              <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/html/H54\">H54: Using the dfn element to identify the defining instance of a word</a>\n                           </li>\n                        </ul>\n                     </li>\n                  </ul>\n               </li>\n            </ul>"
+                    "techniques": [
+                      {
+                        "id": "G101",
+                        "technology": "general",
+                        "title": "Providing the definition of a word or phrase used in an unusual or restricted way",
+                        "suffix": "for each occurrence of the word or phrase in a web page using one of the following techniques:",
+                        "using": [
+                          {
+                            "id": "G55",
+                            "technology": "general",
+                            "title": "Linking to definitions",
+                            "using": [
+                              {
+                                "id": "H40",
+                                "technology": "html",
+                                "title": "Using description lists"
+                              }
+                            ]
+                          },
+                          {
+                            "id": "G112",
+                            "technology": "general",
+                            "title": "Using inline definitions",
+                            "using": [
+                              {
+                                "id": "H54",
+                                "technology": "html",
+                                "title": "Using the dfn element to identify the defining instance of a word"
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
                   }
                 ]
               }
@@ -2194,18 +5204,95 @@
               ],
               "level": "AAA",
               "details": [],
-              "techniquesHtml": {
+              "techniques": {
                 "sufficient": [
                   {
                     "title": "Situation A: If the abbreviation has only one meaning within the web page:",
-                    "content": "<ul>\n               <li>\n                  <p> \n                     <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G102\">G102: Providing the expansion or explanation of an abbreviation</a> for the first occurrence of the abbreviation in a web page using one of the following\n                     techniques:\n                  </p>\n                  <ul>\n                     <li>\n                        <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G97\">G97: Providing the first use of an abbreviation immediately before or after the expanded form</a>\n                     </li>\n                     <li>\n                        <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G55\">G55: Linking to definitions</a>\n                     </li>\n                     <li>\n                        <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/pdf/PDF8\">PDF8: Providing definitions for abbreviations via an E entry for a structure element</a>\n                     </li>\n                  </ul>\n               </li>\n               <li>\n                  <p> \n                     <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G102\">G102: Providing the expansion or explanation of an abbreviation</a> for all occurrences of the abbreviation in a web page using one of the following\n                     techniques:\n                  </p>\n                  <ul>\n                     <li>\n                        <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G55\">G55: Linking to definitions</a>\n                     </li>\n                     <li>\n                        <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G62\">G62: Providing a glossary</a>\n                     </li>\n                     <li>\n                        <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G70\">G70: Providing a function to search an online dictionary</a>\n                     </li>\n                     <li>\n                        <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/pdf/PDF8\">PDF8: Providing definitions for abbreviations via an E entry for a structure element</a>\n                     </li>\n                  </ul>\n               </li>\n            </ul>"
+                    "techniques": [
+                      {
+                        "id": "G102",
+                        "technology": "general",
+                        "title": "Providing the expansion or explanation of an abbreviation",
+                        "suffix": "for the first occurrence of the abbreviation in a web page using one of the following techniques:",
+                        "using": [
+                          {
+                            "id": "G97",
+                            "technology": "general",
+                            "title": "Providing the first use of an abbreviation immediately before or after the expanded form"
+                          },
+                          {
+                            "id": "G55",
+                            "technology": "general",
+                            "title": "Linking to definitions"
+                          },
+                          {
+                            "id": "PDF8",
+                            "technology": "pdf",
+                            "title": "Providing definitions for abbreviations via an E entry for a structure element"
+                          }
+                        ]
+                      },
+                      {
+                        "id": "G102",
+                        "technology": "general",
+                        "title": "Providing the expansion or explanation of an abbreviation",
+                        "suffix": "for all occurrences of the abbreviation in a web page using one of the following techniques:",
+                        "using": [
+                          {
+                            "id": "G55",
+                            "technology": "general",
+                            "title": "Linking to definitions"
+                          },
+                          {
+                            "id": "G62",
+                            "technology": "general",
+                            "title": "Providing a glossary"
+                          },
+                          {
+                            "id": "G70",
+                            "technology": "general",
+                            "title": "Providing a function to search an online dictionary"
+                          },
+                          {
+                            "id": "PDF8",
+                            "technology": "pdf",
+                            "title": "Providing definitions for abbreviations via an E entry for a structure element"
+                          }
+                        ]
+                      }
+                    ]
                   },
                   {
                     "title": "Situation B: If the abbreviation means different things within the same web page:",
-                    "content": "<ul>\n               <li>\n                  <p> \n                     <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G102\">G102: Providing the expansion or explanation of an abbreviation</a> for all occurrences of abbreviations in a web page using one of the following techniques:\n                  </p>\n                  <ul>\n                     <li>\n                        <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G55\">G55: Linking to definitions</a>\n                     </li>\n                     <li>\n                        <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/pdf/PDF8\">PDF8: Providing definitions for abbreviations via an E entry for a structure element</a>\n                     </li>\n                  </ul>\n               </li>\n            </ul>"
+                    "techniques": [
+                      {
+                        "id": "G102",
+                        "technology": "general",
+                        "title": "Providing the expansion or explanation of an abbreviation",
+                        "suffix": "for all occurrences of abbreviations in a web page using one of the following techniques:",
+                        "using": [
+                          {
+                            "id": "G55",
+                            "technology": "general",
+                            "title": "Linking to definitions"
+                          },
+                          {
+                            "id": "PDF8",
+                            "technology": "pdf",
+                            "title": "Providing definitions for abbreviations via an E entry for a structure element"
+                          }
+                        ]
+                      }
+                    ]
                   }
                 ],
-                "advisory": "<ul>\n           <li><a href=\"https://www.w3.org/WAI/WCAG22/Techniques/html/H28\">H28: Providing definitions for abbreviations by using the abbr element</a></li>\n         </ul>"
+                "advisory": [
+                  {
+                    "id": "H28",
+                    "technology": "html",
+                    "title": "Providing definitions for abbreviations by using the abbr element"
+                  }
+                ]
               }
             },
             {
@@ -2223,8 +5310,35 @@
               ],
               "level": "AAA",
               "details": [],
-              "techniquesHtml": {
-                "sufficient": "<ul>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G86\">G86: Providing a text summary that can be understood by people with lower secondary education level reading ability</a>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G103\">G103: Providing visual illustrations, pictures, and symbols to help explain ideas, events, and processes</a>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G79\">G79: Providing a spoken version of the text</a>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G153\">G153: Making the text easier to read</a>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G160\">G160: Providing sign language versions of information, ideas, and processes that must be understood in order to use the content</a>\n            </li>\n         </ul>\n         <p class=\"note\">\n\t\t\t\t<em>Note:</em>\n            Different sites may address this success criterion in different ways. An audio version\n               of the content may be helpful to some users. For some people who are deaf, a sign\n               language version of the page may be easier to understand than a written language version\n               since sign language may be their first language. \n               Some sites may decide to do both or other combinations. No technique will help all\n               users who have difficulty. So different techniques are provided as sufficient techniques\n               here for authors trying to make their sites more accessible. Any numbered technique\n               or combination above can be used by a particular site and it is considered sufficient\n               by the Working Group.\n\t\t\t</p>"
+              "techniques": {
+                "sufficient": [
+                  {
+                    "id": "G86",
+                    "technology": "general",
+                    "title": "Providing a text summary that can be understood by people with lower secondary education level reading ability"
+                  },
+                  {
+                    "id": "G103",
+                    "technology": "general",
+                    "title": "Providing visual illustrations, pictures, and symbols to help explain ideas, events, and processes"
+                  },
+                  {
+                    "id": "G79",
+                    "technology": "general",
+                    "title": "Providing a spoken version of the text"
+                  },
+                  {
+                    "id": "G153",
+                    "technology": "general",
+                    "title": "Making the text easier to read"
+                  },
+                  {
+                    "id": "G160",
+                    "technology": "general",
+                    "title": "Providing sign language versions of information, ideas, and processes that must be understood in order to use the content"
+                  }
+                ],
+                "sufficientNote": "Different sites may address this success criterion in different ways. An audio version of the content may be helpful to some users. For some people who are deaf, a sign language version of the page may be easier to understand than a written language version since sign language may be their first language. Some sites may decide to do both or other combinations. No technique will help all users who have difficulty. So different techniques are provided as sufficient techniques here for authors trying to make their sites more accessible. Any numbered technique or combination above can be used by a particular site and it is considered sufficient by the Working Group."
               }
             },
             {
@@ -2242,8 +5356,35 @@
               ],
               "level": "AAA",
               "details": [],
-              "techniquesHtml": {
-                "sufficient": "<ul>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G120\">G120: Providing the pronunciation immediately following the word</a>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G121\">G121: Linking to pronunciations</a>\n            </li>\n            <li> \n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G62\">G62: Providing a glossary</a> that includes pronunciation information for words that have a unique pronunciation\n               in the content and have meaning that depends on pronunciation\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G163\">G163: Using standard diacritical marks that can be turned off</a>\n            </li>\n            <li> \n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/html/H62\">H62: Using the ruby element</a>\n            </li>\n         </ul>"
+              "techniques": {
+                "sufficient": [
+                  {
+                    "id": "G120",
+                    "technology": "general",
+                    "title": "Providing the pronunciation immediately following the word"
+                  },
+                  {
+                    "id": "G121",
+                    "technology": "general",
+                    "title": "Linking to pronunciations"
+                  },
+                  {
+                    "id": "G62",
+                    "technology": "general",
+                    "title": "Providing a glossary",
+                    "suffix": "that includes pronunciation information for words that have a unique pronunciation in the content and have meaning that depends on pronunciation"
+                  },
+                  {
+                    "id": "G163",
+                    "technology": "general",
+                    "title": "Using standard diacritical marks that can be turned off"
+                  },
+                  {
+                    "id": "H62",
+                    "technology": "html",
+                    "title": "Using the ruby element"
+                  }
+                ]
               }
             }
           ]
@@ -2277,10 +5418,34 @@
               ],
               "level": "A",
               "details": [],
-              "techniquesHtml": {
-                "sufficient": "<ul>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G107\">G107: Using \"activate\" rather than \"focus\" as a trigger for changes of context</a>\n            </li>\n         </ul>\n         <p class=\"note\">\n\t\t\t\t<em>Note:</em>\n            A change of content is not always a \n               change of context. This success criterion is automatically met if changes in content are not also changes\n               of context.\n\t\t\t</p>",
-                "advisory": "<ul>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G200\">G200: Opening new windows and tabs from a link only when necessary</a>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G201\">G201: Giving users advanced warning when opening a new window</a>\n            </li>\n         </ul>",
-                "failure": "<ul>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/failures/F55\">F55: Failure of Success Criteria 2.1.1, 2.4.7, 2.4.13, and 3.2.1 due to using script to remove focus when focus is received</a>\n            </li>\n         </ul>"
+              "techniques": {
+                "sufficient": [
+                  {
+                    "id": "G107",
+                    "technology": "general",
+                    "title": "Using \"activate\" rather than \"focus\" as a trigger for changes of context"
+                  }
+                ],
+                "sufficientNote": "A change of content is not always a change of context. This success criterion is automatically met if changes in content are not also changes of context.",
+                "advisory": [
+                  {
+                    "id": "G200",
+                    "technology": "general",
+                    "title": "Opening new windows and tabs from a link only when necessary"
+                  },
+                  {
+                    "id": "G201",
+                    "technology": "general",
+                    "title": "Giving users advanced warning when opening a new window"
+                  }
+                ],
+                "failure": [
+                  {
+                    "id": "F55",
+                    "technology": "failures",
+                    "title": "Failure of Success Criteria 2.1.1, 2.4.7, 2.4.13, and 3.2.1 due to using script to remove focus when focus is received"
+                  }
+                ]
               }
             },
             {
@@ -2298,10 +5463,62 @@
               ],
               "level": "A",
               "details": [],
-              "techniquesHtml": {
-                "sufficient": "<ul>\n            <li>\n               <p> \n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G80\">G80: Providing a submit button to initiate a change of context</a> using a technology-specific technique listed below\n               </p>\n               <ul>\n                  <li>\n                     <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/html/H32\">H32: Providing submit buttons</a>\n                  </li>\n                  <li>\n                     <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/html/H84\">H84: Using a button with a select element to perform an action</a>\n                  </li>\n                  <li>\n                     <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/pdf/PDF15\">PDF15: Providing submit buttons with the submit-form action in PDF forms</a>\n                  </li>\n               </ul>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G13\">G13: Describing what will happen before a change to a form control that causes a change of context to occur is made</a>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/client-side-script/SCR19\">SCR19: Using an onchange event on a select element without causing a change of context</a>\n            </li>\n         </ul>\n         <p class=\"note\">\n\t\t\t\t<em>Note:</em>\n            A change of content is not always a \n               change of context. This success criterion is automatically met if changes in content are not also changes\n               of context.\n\t\t\t</p>",
-                "advisory": "<ul>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G201\">G201: Giving users advanced warning when opening a new window</a>\n            </li>\n         </ul>",
-                "failure": "<ul>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/failures/F36\">F36: Failure of Success Criterion 3.2.2 due to automatically submitting a form and presenting new content without prior warning when the last field in the form is given a value</a>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/failures/F37\">F37: Failure of Success Criterion 3.2.2 due to launching a new window without prior warning when the selection of a radio button, check box or select list is changed</a>\n            </li>\n         </ul>"
+              "techniques": {
+                "sufficient": [
+                  {
+                    "id": "G80",
+                    "technology": "general",
+                    "title": "Providing a submit button to initiate a change of context",
+                    "suffix": "using one of the following techniques:",
+                    "using": [
+                      {
+                        "id": "H32",
+                        "technology": "html",
+                        "title": "Providing submit buttons"
+                      },
+                      {
+                        "id": "H84",
+                        "technology": "html",
+                        "title": "Using a button with a select element to perform an action"
+                      },
+                      {
+                        "id": "PDF15",
+                        "technology": "pdf",
+                        "title": "Providing submit buttons with the submit-form action in PDF forms"
+                      }
+                    ]
+                  },
+                  {
+                    "id": "G13",
+                    "technology": "general",
+                    "title": "Describing what will happen before a change to a form control that causes a change of context to occur is made"
+                  },
+                  {
+                    "id": "SCR19",
+                    "technology": "client-side-script",
+                    "title": "Using an onchange event on a select element without causing a change of context"
+                  }
+                ],
+                "sufficientNote": "A change of content is not always a change of context. This success criterion is automatically met if changes in content are not also changes of context.",
+                "advisory": [
+                  {
+                    "id": "G201",
+                    "technology": "general",
+                    "title": "Giving users advanced warning when opening a new window"
+                  }
+                ],
+                "failure": [
+                  {
+                    "id": "F36",
+                    "technology": "failures",
+                    "title": "Failure of Success Criterion 3.2.2 due to automatically submitting a form and presenting new content without prior warning when the last field in the form is given a value"
+                  },
+                  {
+                    "id": "F37",
+                    "technology": "failures",
+                    "title": "Failure of Success Criterion 3.2.2 due to launching a new window without prior warning when the selection of a radio button, check box or select list is changed"
+                  }
+                ]
               }
             },
             {
@@ -2319,10 +5536,33 @@
               ],
               "level": "AA",
               "details": [],
-              "techniquesHtml": {
-                "sufficient": "<ul>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G61\">G61: Presenting repeated components in the same relative order each time they appear</a>\n            </li>\n         </ul>",
-                "advisory": "<ul>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/pdf/PDF14\">PDF14: Providing running headers and footers in PDF documents</a>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/pdf/PDF17\">PDF17: Specifying consistent page numbering for PDF documents</a>\n            </li>\n         </ul>",
-                "failure": "<ul>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/failures/F66\">F66: Failure of Success Criterion 3.2.3 due to presenting navigation links in a different relative order on different pages</a>\n            </li>\n         </ul>"
+              "techniques": {
+                "sufficient": [
+                  {
+                    "id": "G61",
+                    "technology": "general",
+                    "title": "Presenting repeated components in the same relative order each time they appear"
+                  }
+                ],
+                "advisory": [
+                  {
+                    "id": "PDF14",
+                    "technology": "pdf",
+                    "title": "Providing running headers and footers in PDF documents"
+                  },
+                  {
+                    "id": "PDF17",
+                    "technology": "pdf",
+                    "title": "Specifying consistent page numbering for PDF documents"
+                  }
+                ],
+                "failure": [
+                  {
+                    "id": "F66",
+                    "technology": "failures",
+                    "title": "Failure of Success Criterion 3.2.3 due to presenting navigation links in a different relative order on different pages"
+                  }
+                ]
               }
             },
             {
@@ -2340,9 +5580,29 @@
               ],
               "level": "AA",
               "details": [],
-              "techniquesHtml": {
-                "sufficient": "<ul>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G197\">G197: Using labels, names, and text alternatives consistently for content that has the same functionality</a>\n               <strong>AND</strong> following the \n               <a href=\"non-text-content#techniques\" class=\"understanding\">sufficient techniques for Success Criterion 1.1.1</a> and \n               <a href=\"name-role-value#techniques\" class=\"understanding\">sufficient techniques for Success Criterion 4.1.2</a> for providing labels, names, and text alternatives.\n            </li>\n         </ul>\n         <div class=\"note\">\n\t\t\t\t<p class=\"note-title marker\">Note</p>\n\t\t\t\t<div>\n            <p>Text alternatives that are \"consistent\" are not always \"identical.\" For instance,\n               you may have a graphical arrow at the bottom of a web page that links to the next\n               web page. The text alternative may say \"Go to page 4.\" Naturally, it would not be\n               appropriate to repeat this exact text alternative on the next web page. It would be\n               more appropriate to say \"Go to page 5\". Although these text alternatives would not\n               be identical, they would be consistent, and therefore would satisfy this success criterion.\n            </p>\n            <p> A single non-text-content-item may be used to serve different functions. In such\n               cases, different text alternatives are necessary and should be used. Examples can\n               be commonly found with the use of icons such as check marks, cross marks, and traffic\n               signs. Their functions can be different depending on the context of the web page.\n               A check mark icon may function as \"approved\", \"completed\", or \"included\", to name\n               a few, depending on the situation. Using \"check mark\" as text alternative across all\n               web pages does not help users understand the function of the icon. Different text\n               alternatives can be used when the same non-text content serves multiple functions.\n            </p>\n         </div>\n\t\t\t</div>",
-                "failure": "<ul>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/failures/F31\">F31: Failure of Success Criterion 3.2.4 due to using two different labels for the same function on different web pages within a set of web pages </a>\n            </li>\n         </ul>"
+              "techniques": {
+                "sufficient": [
+                  {
+                    "and": [
+                      {
+                        "id": "G197",
+                        "technology": "general",
+                        "title": "Using labels, names, and text alternatives consistently for content that has the same functionality"
+                      },
+                      {
+                        "title": "following the <a href=\"https://www.w3.org/WAI/WCAG22/Understanding/non-text-content#techniques\">sufficient techniques for Success Criterion 1.1.1</a> and <a href=\"https://www.w3.org/WAI/WCAG22/Understanding/name-role-value#techniques\">sufficient techniques for Success Criterion 4.1.2</a> for providing labels, names, and text alternatives"
+                      }
+                    ]
+                  }
+                ],
+                "sufficientNote": "<p> Text alternatives that are \"consistent\" are not always \"identical.\" For instance, you may have a graphical arrow at the bottom of a web page that links to the next web page. The text alternative may say \"Go to page 4.\" Naturally, it would not be appropriate to repeat this exact text alternative on the next web page. It would be more appropriate to say \"Go to page 5\". Although these text alternatives would not be identical, they would be consistent, and therefore would satisfy this success criterion. </p><p> A single non-text-content-item may be used to serve different functions. In such cases, different text alternatives are necessary and should be used. Examples can be commonly found with the use of icons such as check marks, cross marks, and traffic signs. Their functions can be different depending on the context of the web page. A check mark icon may function as \"approved\", \"completed\", or \"included\", to name a few, depending on the situation. Using \"check mark\" as text alternative across all web pages does not help users understand the function of the icon. Different text alternatives can be used when the same non-text content serves multiple functions. </p>",
+                "failure": [
+                  {
+                    "id": "F31",
+                    "technology": "failures",
+                    "title": "Failure of Success Criterion 3.2.4 due to using two different labels for the same function on different web pages within a set of web pages"
+                  }
+                ]
               }
             },
             {
@@ -2360,27 +5620,117 @@
               ],
               "level": "AAA",
               "details": [],
-              "techniquesHtml": {
+              "techniques": {
                 "sufficient": [
                   {
                     "title": "Situation A: If the web page allows automatic updates:",
-                    "content": "<ul>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G76\">G76: Providing a mechanism to request an update of the content instead of updating automatically</a>\n               </li>\n            </ul>"
+                    "techniques": [
+                      {
+                        "id": "G76",
+                        "technology": "general",
+                        "title": "Providing a mechanism to request an update of the content instead of updating automatically"
+                      }
+                    ]
                   },
                   {
                     "title": "Situation B: If automatic redirects are possible:",
-                    "content": "<ul>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/server-side-script/SVR1\">SVR1: Implementing automatic redirects on the server side instead of on the client side</a>\n               </li>\n               <li>\n                  <p> \n                     <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G110\">G110: Using an instant client-side redirect</a> using one of the following techniques:    \n                  </p>\n                  <ul>\n                     <li>\n                        <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/html/H76\">H76: Using meta refresh to create an instant client-side redirect</a>\n                     </li>\n                  </ul>\n               </li>\n            </ul>"
+                    "techniques": [
+                      {
+                        "id": "SVR1",
+                        "technology": "server-side-script",
+                        "title": "Implementing automatic redirects on the server side instead of on the client side"
+                      },
+                      {
+                        "id": "G110",
+                        "technology": "general",
+                        "title": "Using an instant client-side redirect",
+                        "suffix": "using one of the following techniques:",
+                        "using": [
+                          {
+                            "id": "H76",
+                            "technology": "html",
+                            "title": "Using meta refresh to create an instant client-side redirect"
+                          }
+                        ]
+                      }
+                    ]
                   },
                   {
                     "title": "Situation C: If the web page uses pop-up windows:",
-                    "content": "<ul>\n               <li>\n                  <p>Including pop-up windows using one of the following techniques:    </p>\n                  <ul>\n                     <li>\n                        <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/html/H83\">H83: Using the target attribute to open a new window on user request and indicating this in link text</a>\n                     </li>\n                     <li>\n                        <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/client-side-script/SCR24\">SCR24: Using progressive enhancement to open new windows on user request</a>\n                     </li>\n                  </ul>\n               </li>\n            </ul>"
+                    "techniques": [
+                      {
+                        "title": "Including pop-up windows",
+                        "suffix": "using one of the following techniques:",
+                        "using": [
+                          {
+                            "id": "H83",
+                            "technology": "html",
+                            "title": "Using the target attribute to open a new window on user request and indicating this in link text"
+                          },
+                          {
+                            "id": "SCR24",
+                            "technology": "client-side-script",
+                            "title": "Using progressive enhancement to open new windows on user request"
+                          }
+                        ]
+                      }
+                    ]
                   },
                   {
                     "title": "Situation D: If using an onchange event on a select element:",
-                    "content": "<ul>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/client-side-script/SCR19\">SCR19: Using an onchange event on a select element without causing a change of context</a>\n               </li>\n            </ul>"
+                    "techniques": [
+                      {
+                        "id": "SCR19",
+                        "technology": "client-side-script",
+                        "title": "Using an onchange event on a select element without causing a change of context"
+                      }
+                    ]
                   }
                 ],
-                "advisory": "<ul>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G200\">G200: Opening new windows and tabs from a link only when necessary</a>\n            </li>\n         </ul>",
-                "failure": "<ul>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/failures/F60\">F60: Failure of Success Criterion 3.2.5 due to launching a new window when a user enters text into an input field</a>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/failures/F61\">F61: Failure of Success Criterion 3.2.5 due to complete change of main content through an automatic update that the user cannot disable from within the content</a>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/failures/F9\">F9: Failure of Success Criterion 3.2.5 due to changing the context when the user removes focus from a form element</a>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/failures/F22\">F22: Failure of Success Criterion 3.2.5 due to opening windows that are not requested by the user</a>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/failures/F52\">F52: Failure of Success Criterion 3.2.5 due to opening a new window as soon as a new page is loaded</a>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/failures/F40\">F40: Failure due to using meta redirect with a time limit </a>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/failures/F41\">F41: Failure of Success Criterion 2.2.1, 2.2.4, and 3.2.5 due to using meta refresh to reload the page</a>\n            </li>\n         </ul>"
+                "advisory": [
+                  {
+                    "id": "G200",
+                    "technology": "general",
+                    "title": "Opening new windows and tabs from a link only when necessary"
+                  }
+                ],
+                "failure": [
+                  {
+                    "id": "F60",
+                    "technology": "failures",
+                    "title": "Failure of Success Criterion 3.2.5 due to launching a new window when a user enters text into an input field"
+                  },
+                  {
+                    "id": "F61",
+                    "technology": "failures",
+                    "title": "Failure of Success Criterion 3.2.5 due to complete change of main content through an automatic update that the user cannot disable from within the content"
+                  },
+                  {
+                    "id": "F9",
+                    "technology": "failures",
+                    "title": "Failure of Success Criterion 3.2.5 due to changing the context when the user removes focus from a form element"
+                  },
+                  {
+                    "id": "F22",
+                    "technology": "failures",
+                    "title": "Failure of Success Criterion 3.2.5 due to opening windows that are not requested by the user"
+                  },
+                  {
+                    "id": "F52",
+                    "technology": "failures",
+                    "title": "Failure of Success Criterion 3.2.5 due to opening a new window as soon as a new page is loaded"
+                  },
+                  {
+                    "id": "F40",
+                    "technology": "failures",
+                    "title": "Failure due to using meta redirect with a time limit"
+                  },
+                  {
+                    "id": "F41",
+                    "technology": "failures",
+                    "title": "Failure of Success Criterion 2.2.1, 2.2.4, and 3.2.5 due to using meta refresh to reload the page"
+                  }
+                ]
               }
             },
             {
@@ -2422,9 +5772,19 @@
                   "text": "For this success criterion, \"the same order relative to other page content\" can be thought of as how the content is ordered when the page is serialized. The visual position of a help mechanism is likely to be consistent across pages for the same page variation (e.g., CSS break-point). The user can initiate a change, such as changing the page's zoom or orientation, which may trigger a different page variation. This criterion is concerned with relative order across pages displayed in the same page variation (e.g., same zoom level and orientation)."
                 }
               ],
-              "techniquesHtml": {
-                "sufficient": "<ul>\n            <li><a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G220\">G220: Provide a contact-us link in a consistent location</a></li>\n         </ul>",
-                "failure": "<ul>\n            <li>Inconsistent Help Location\n            </li>\n         </ul>"
+              "techniques": {
+                "sufficient": [
+                  {
+                    "id": "G220",
+                    "technology": "general",
+                    "title": "Provide a contact-us link in a consistent location"
+                  }
+                ],
+                "failure": [
+                  {
+                    "title": "Inconsistent Help Location"
+                  }
+                ]
               }
             }
           ]
@@ -2458,18 +5818,96 @@
               ],
               "level": "A",
               "details": [],
-              "techniquesHtml": {
+              "techniques": {
                 "sufficient": [
                   {
                     "title": "Situation A: If a form contains fields for which information from the user is mandatory.",
-                    "content": "<ul>\n               <li><a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G83\">G83: Providing text descriptions to identify required fields that were not completed</a></li>\n               <li><a href=\"https://www.w3.org/WAI/WCAG22/Techniques/aria/ARIA2\">ARIA2: Identifying a required field with the aria-required property</a></li>\n               <li><a href=\"https://www.w3.org/WAI/WCAG22/Techniques/aria/ARIA21\">ARIA21: Using aria-invalid to Indicate An Error Field</a></li>\n               <li><a href=\"https://www.w3.org/WAI/WCAG22/Techniques/client-side-script/SCR18\">SCR18: Providing client-side validation and alert</a></li>\n               <li><a href=\"https://www.w3.org/WAI/WCAG22/Techniques/pdf/PDF5\">PDF5: Indicating required form controls in PDF forms</a></li>\n            </ul>"
+                    "techniques": [
+                      {
+                        "id": "G83",
+                        "technology": "general",
+                        "title": "Providing text descriptions to identify required fields that were not completed"
+                      },
+                      {
+                        "id": "ARIA2",
+                        "technology": "aria",
+                        "title": "Identifying a required field with the aria-required property"
+                      },
+                      {
+                        "id": "ARIA21",
+                        "technology": "aria",
+                        "title": "Using aria-invalid to Indicate An Error Field"
+                      },
+                      {
+                        "id": "SCR18",
+                        "technology": "client-side-script",
+                        "title": "Providing client-side validation and alert"
+                      },
+                      {
+                        "id": "PDF5",
+                        "technology": "pdf",
+                        "title": "Indicating required form controls in PDF forms"
+                      }
+                    ]
                   },
                   {
-                    "title": "Situation B: If information provided by the user is required to be in a specific data\n               format or of certain values.",
-                    "content": "<ul>\n               <li><a href=\"https://www.w3.org/WAI/WCAG22/Techniques/aria/ARIA18\">ARIA18: Using aria-alertdialog to Identify Errors</a></li>\n               <li><a href=\"https://www.w3.org/WAI/WCAG22/Techniques/aria/ARIA19\">ARIA19: Using ARIA role=alert or Live Regions to Identify Errors</a></li>\n               <li><a href=\"https://www.w3.org/WAI/WCAG22/Techniques/aria/ARIA21\">ARIA21: Using aria-invalid to Indicate An Error Field</a></li>\n               <li><a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G84\">G84: Providing a text description when the user provides information that is not in the list of allowed values</a></li>\n               <li><a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G85\">G85: Providing a text description when user input falls outside the required format or values</a></li>\n               <li><a href=\"https://www.w3.org/WAI/WCAG22/Techniques/client-side-script/SCR18\">SCR18: Providing client-side validation and alert</a></li>\n               <li><a href=\"https://www.w3.org/WAI/WCAG22/Techniques/client-side-script/SCR32\">SCR32: Providing client-side validation and adding error text via the DOM</a></li>\n               <li><a href=\"https://www.w3.org/WAI/WCAG22/Techniques/pdf/PDF22\">PDF22: Indicating when user input falls outside the required format or values in PDF forms</a></li>\n            </ul>"
+                    "title": "Situation B: If information provided by the user is required to be in a specific data format or of certain values.",
+                    "techniques": [
+                      {
+                        "id": "ARIA18",
+                        "technology": "aria",
+                        "title": "Using aria-alertdialog to Identify Errors"
+                      },
+                      {
+                        "id": "ARIA19",
+                        "technology": "aria",
+                        "title": "Using ARIA role=alert or Live Regions to Identify Errors"
+                      },
+                      {
+                        "id": "ARIA21",
+                        "technology": "aria",
+                        "title": "Using aria-invalid to Indicate An Error Field"
+                      },
+                      {
+                        "id": "G84",
+                        "technology": "general",
+                        "title": "Providing a text description when the user provides information that is not in the list of allowed values"
+                      },
+                      {
+                        "id": "G85",
+                        "technology": "general",
+                        "title": "Providing a text description when user input falls outside the required format or values"
+                      },
+                      {
+                        "id": "SCR18",
+                        "technology": "client-side-script",
+                        "title": "Providing client-side validation and alert"
+                      },
+                      {
+                        "id": "SCR32",
+                        "technology": "client-side-script",
+                        "title": "Providing client-side validation and adding error text via the DOM"
+                      },
+                      {
+                        "id": "PDF22",
+                        "technology": "pdf",
+                        "title": "Indicating when user input falls outside the required format or values in PDF forms"
+                      }
+                    ]
                   }
                 ],
-                "advisory": "<ul>\n            <li><a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G139\">G139: Creating a mechanism that allows users to jump to errors</a></li>\n            <li><a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G199\">G199: Providing success feedback when data is submitted successfully</a></li>\n         </ul>"
+                "advisory": [
+                  {
+                    "id": "G139",
+                    "technology": "general",
+                    "title": "Creating a mechanism that allows users to jump to errors"
+                  },
+                  {
+                    "id": "G199",
+                    "technology": "general",
+                    "title": "Providing success feedback when data is submitted successfully"
+                  }
+                ]
               }
             },
             {
@@ -2487,10 +5925,97 @@
               ],
               "level": "A",
               "details": [],
-              "techniquesHtml": {
-                "sufficient": "<ul>\n            <li>\n               <p> \n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G131\">G131: Providing descriptive labels</a> \n                  <strong>AND</strong> one of the following:\n               </p>\n               <ul>\n                  <li>\n                     <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/aria/ARIA1\">ARIA1: Using the aria-describedby property to provide a descriptive label for user interface controls</a>\n                  </li>\n                  <li>\n                     <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/aria/ARIA9\">ARIA9: Using aria-labelledby to concatenate a label from several text nodes</a>\n                  </li>\n                  <li>\n                     <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/aria/ARIA17\">ARIA17: Using grouping roles to identify related form controls</a>\n                  </li>\n                  <li>\n                     <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G89\">G89: Providing expected data format and example</a>\n                  </li>\n                  <li>\n                     <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G184\">G184: Providing text instructions at the beginning of a form or set of fields that describes the necessary input</a>\n                  </li>\n                  <li>\n                     <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G162\">G162: Positioning labels to maximize predictability of relationships</a>\n                  </li>\n                  <li>\n                     <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G83\">G83: Providing text descriptions to identify required fields that were not completed</a>\n                  </li>\n                  <li>\n                     <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/html/H90\">H90: Indicating required form controls using label or legend</a>\n                  </li>\n                  <li>\n                     <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/pdf/PDF5\">PDF5: Indicating required form controls in PDF forms</a>\n                  </li>\n               </ul>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/html/H44\">H44: Using label elements to associate text labels with form controls</a>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/pdf/PDF10\">PDF10: Providing labels for interactive form controls in PDF documents</a>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/html/H71\">H71: Providing a description for groups of form controls using fieldset and legend elements</a>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G167\">G167: Using an adjacent button to label the purpose of a field</a>\n            </li>\n         </ul>\n         <p class=\"note\">\n\t\t\t\t<em>Note:</em>\n            The techniques at the end of the above list should be considered \"last resort\" and\n               only used when the other techniques cannot be applied to the page. The earlier techniques\n               are preferred because they increase accessibility to a wider user group.\n\t\t\t</p>",
-                "advisory": "<ul>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G13\">G13: Describing what will happen before a change to a form control that causes a change of context to occur is made</a>\n            </li>\n         </ul>",
-                "failure": "<ul>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/failures/F82\">F82: Failure of Success Criterion 3.3.2 by visually formatting a set of phone number fields but not including a text label</a>\n            </li>\n         </ul>"
+              "techniques": {
+                "sufficient": [
+                  {
+                    "id": "G131",
+                    "technology": "general",
+                    "title": "Providing descriptive labels",
+                    "suffix": "<strong>AND</strong> one of the following techniques:",
+                    "using": [
+                      {
+                        "id": "ARIA1",
+                        "technology": "aria",
+                        "title": "Using the aria-describedby property to provide a descriptive label for user interface controls"
+                      },
+                      {
+                        "id": "ARIA9",
+                        "technology": "aria",
+                        "title": "Using aria-labelledby to concatenate a label from several text nodes"
+                      },
+                      {
+                        "id": "ARIA17",
+                        "technology": "aria",
+                        "title": "Using grouping roles to identify related form controls"
+                      },
+                      {
+                        "id": "G89",
+                        "technology": "general",
+                        "title": "Providing expected data format and example"
+                      },
+                      {
+                        "id": "G184",
+                        "technology": "general",
+                        "title": "Providing text instructions at the beginning of a form or set of fields that describes the necessary input"
+                      },
+                      {
+                        "id": "G162",
+                        "technology": "general",
+                        "title": "Positioning labels to maximize predictability of relationships"
+                      },
+                      {
+                        "id": "G83",
+                        "technology": "general",
+                        "title": "Providing text descriptions to identify required fields that were not completed"
+                      },
+                      {
+                        "id": "H90",
+                        "technology": "html",
+                        "title": "Indicating required form controls using label or legend"
+                      },
+                      {
+                        "id": "PDF5",
+                        "technology": "pdf",
+                        "title": "Indicating required form controls in PDF forms"
+                      }
+                    ]
+                  },
+                  {
+                    "id": "H44",
+                    "technology": "html",
+                    "title": "Using label elements to associate text labels with form controls"
+                  },
+                  {
+                    "id": "PDF10",
+                    "technology": "pdf",
+                    "title": "Providing labels for interactive form controls in PDF documents"
+                  },
+                  {
+                    "id": "H71",
+                    "technology": "html",
+                    "title": "Providing a description for groups of form controls using fieldset and legend elements"
+                  },
+                  {
+                    "id": "G167",
+                    "technology": "general",
+                    "title": "Using an adjacent button to label the purpose of a field"
+                  }
+                ],
+                "sufficientNote": "The techniques at the end of the above list should be considered \"last resort\" and only used when the other techniques cannot be applied to the page. The earlier techniques are preferred because they increase accessibility to a wider user group.",
+                "advisory": [
+                  {
+                    "id": "G13",
+                    "technology": "general",
+                    "title": "Describing what will happen before a change to a form control that causes a change of context to occur is made"
+                  }
+                ],
+                "failure": [
+                  {
+                    "id": "F82",
+                    "technology": "failures",
+                    "title": "Failure of Success Criterion 3.3.2 by visually formatting a set of phone number fields but not including a text label"
+                  }
+                ]
               }
             },
             {
@@ -2508,18 +6033,82 @@
               ],
               "level": "AA",
               "details": [],
-              "techniquesHtml": {
+              "techniques": {
                 "sufficient": [
                   {
                     "title": "Situation A: If information for a field is required to be in a specific data format:",
-                    "content": "<ul>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/aria/ARIA18\">ARIA18: Using aria-alertdialog to Identify Errors</a>\n               </li>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G85\">G85: Providing a text description when user input falls outside the required format or values</a>\n               </li>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G177\">G177: Providing suggested correction text</a>\n               </li>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/pdf/PDF22\">PDF22: Indicating when user input falls outside the required format or values in PDF forms</a>\n               </li>\n            </ul>"
+                    "techniques": [
+                      {
+                        "id": "ARIA18",
+                        "technology": "aria",
+                        "title": "Using aria-alertdialog to Identify Errors"
+                      },
+                      {
+                        "id": "G85",
+                        "technology": "general",
+                        "title": "Providing a text description when user input falls outside the required format or values"
+                      },
+                      {
+                        "id": "G177",
+                        "technology": "general",
+                        "title": "Providing suggested correction text"
+                      },
+                      {
+                        "id": "PDF22",
+                        "technology": "pdf",
+                        "title": "Indicating when user input falls outside the required format or values in PDF forms"
+                      }
+                    ]
                   },
                   {
-                    "title": "Situation B: Information provided by the user is required to be one of a limited set\n               of values:",
-                    "content": "<ul>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/aria/ARIA18\">ARIA18: Using aria-alertdialog to Identify Errors</a>\n               </li>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G84\">G84: Providing a text description when the user provides information that is not in the list of allowed values</a>\n               </li>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G177\">G177: Providing suggested correction text</a>\n               </li>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/pdf/PDF22\">PDF22: Indicating when user input falls outside the required format or values in PDF forms</a>\n               </li>\n            </ul>"
+                    "title": "Situation B: Information provided by the user is required to be one of a limited set of values:",
+                    "techniques": [
+                      {
+                        "id": "ARIA18",
+                        "technology": "aria",
+                        "title": "Using aria-alertdialog to Identify Errors"
+                      },
+                      {
+                        "id": "G84",
+                        "technology": "general",
+                        "title": "Providing a text description when the user provides information that is not in the list of allowed values"
+                      },
+                      {
+                        "id": "G177",
+                        "technology": "general",
+                        "title": "Providing suggested correction text"
+                      },
+                      {
+                        "id": "PDF22",
+                        "technology": "pdf",
+                        "title": "Indicating when user input falls outside the required format or values in PDF forms"
+                      }
+                    ]
                   }
                 ],
-                "advisory": "<ul>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G139\">G139: Creating a mechanism that allows users to jump to errors</a>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G199\">G199: Providing success feedback when data is submitted successfully</a>\n            </li>\n         <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/client-side-script/SCR18\">SCR18: Providing client-side validation and alert</a>\n               </li><li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/client-side-script/SCR32\">SCR32: Providing client-side validation and adding error text via the DOM</a>\n               </li></ul>"
+                "sufficientNote": "In some cases, more than one of these situations may apply. For example, when a mandatory field also requires the data to be in a specific format.",
+                "advisory": [
+                  {
+                    "id": "G139",
+                    "technology": "general",
+                    "title": "Creating a mechanism that allows users to jump to errors"
+                  },
+                  {
+                    "id": "G199",
+                    "technology": "general",
+                    "title": "Providing success feedback when data is submitted successfully"
+                  },
+                  {
+                    "id": "SCR18",
+                    "technology": "client-side-script",
+                    "title": "Providing client-side validation and alert"
+                  },
+                  {
+                    "id": "SCR32",
+                    "technology": "client-side-script",
+                    "title": "Providing client-side validation and adding error text via the DOM"
+                  }
+                ]
               }
             },
             {
@@ -2555,22 +6144,76 @@
                   ]
                 }
               ],
-              "techniquesHtml": {
+              "techniques": {
                 "sufficient": [
                   {
-                    "title": "Situation A: If an application causes a legal transaction to occur, such as making\n               a purchase or submitting an income tax return:",
-                    "content": "<ul>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G164\">G164: Providing a stated time within which an online request (or transaction) may be amended or canceled by the user after making the request</a>\n               </li>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G98\">G98: Providing the ability for the user to review and correct answers before submitting</a>\n               </li>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G155\">G155: Providing a checkbox in addition to a submit button</a>\n               </li>\n            </ul>"
+                    "title": "Situation A: If an application causes a legal transaction to occur, such as making a purchase or submitting an income tax return:",
+                    "techniques": [
+                      {
+                        "id": "G164",
+                        "technology": "general",
+                        "title": "Providing a stated time within which an online request (or transaction) may be amended or canceled by the user after making the request"
+                      },
+                      {
+                        "id": "G98",
+                        "technology": "general",
+                        "title": "Providing the ability for the user to review and correct answers before submitting"
+                      },
+                      {
+                        "id": "G155",
+                        "technology": "general",
+                        "title": "Providing a checkbox in addition to a submit button"
+                      }
+                    ]
                   },
                   {
                     "title": "Situation B: If an action causes information to be deleted:",
-                    "content": "<ul>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G99\">G99: Providing the ability to recover deleted information</a>\n               </li>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G168\">G168: Requesting confirmation to continue with selected action</a>\n               </li>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G155\">G155: Providing a checkbox in addition to a submit button</a>\n               </li>\n            </ul>"
+                    "techniques": [
+                      {
+                        "id": "G99",
+                        "technology": "general",
+                        "title": "Providing the ability to recover deleted information"
+                      },
+                      {
+                        "id": "G168",
+                        "technology": "general",
+                        "title": "Requesting confirmation to continue with selected action"
+                      },
+                      {
+                        "id": "G155",
+                        "technology": "general",
+                        "title": "Providing a checkbox in addition to a submit button"
+                      }
+                    ]
                   },
                   {
-                    "title": "Situation C: If the web page includes a testing application:",
-                    "content": "<ul>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G98\">G98: Providing the ability for the user to review and correct answers before submitting</a>\n               </li>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G168\">G168: Requesting confirmation to continue with selected action</a>\n               </li>\n            </ul>"
+                    "title": "Situation C: If the web page includes a testing application",
+                    "techniques": [
+                      {
+                        "id": "G98",
+                        "technology": "general",
+                        "title": "Providing the ability for the user to review and correct answers before submitting"
+                      },
+                      {
+                        "id": "G168",
+                        "technology": "general",
+                        "title": "Requesting confirmation to continue with selected action"
+                      }
+                    ]
                   }
                 ],
-                "advisory": "<ul>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/client-side-script/SCR18\">SCR18: Providing client-side validation and alert</a>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G199\">G199: Providing success feedback when data is submitted successfully</a>\n            </li>\n         </ul>"
+                "advisory": [
+                  {
+                    "id": "SCR18",
+                    "technology": "client-side-script",
+                    "title": "Providing client-side validation and alert"
+                  },
+                  {
+                    "id": "G199",
+                    "technology": "general",
+                    "title": "Providing success feedback when data is submitted successfully"
+                  }
+                ]
               }
             },
             {
@@ -2588,18 +6231,56 @@
               ],
               "level": "AAA",
               "details": [],
-              "techniquesHtml": {
+              "techniques": {
                 "sufficient": [
                   {
                     "title": "Situation A: If a form requires text input:",
-                    "content": "<ul>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G71\">G71: Providing a help link on every web page</a>\n               </li>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G193\">G193: Providing help by an assistant in the web page</a>\n               </li>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G194\">G194: Providing spell checking and suggestions for text input</a>\n               </li>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G184\">G184: Providing text instructions at the beginning of a form or set of fields that describes the necessary input</a>\n               </li>\n            </ul>"
+                    "techniques": [
+                      {
+                        "id": "G71",
+                        "technology": "general",
+                        "title": "Providing a help link on every web page"
+                      },
+                      {
+                        "id": "G193",
+                        "technology": "general",
+                        "title": "Providing help by an assistant in the web page"
+                      },
+                      {
+                        "id": "G194",
+                        "technology": "general",
+                        "title": "Providing spell checking and suggestions for text input"
+                      },
+                      {
+                        "id": "G184",
+                        "technology": "general",
+                        "title": "Providing text instructions at the beginning of a form or set of fields that describes the necessary input"
+                      }
+                    ]
                   },
                   {
                     "title": "Situation B: If a form requires text input in an expected data format:",
-                    "content": "<ul>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G89\">G89: Providing expected data format and example</a>\n               </li>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G184\">G184: Providing text instructions at the beginning of a form or set of fields that describes the necessary input</a>\n               </li>\n            </ul>"
+                    "techniques": [
+                      {
+                        "id": "G89",
+                        "technology": "general",
+                        "title": "Providing expected data format and example"
+                      },
+                      {
+                        "id": "G184",
+                        "technology": "general",
+                        "title": "Providing text instructions at the beginning of a form or set of fields that describes the necessary input"
+                      }
+                    ]
                   }
                 ],
-                "advisory": "<ul>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/html/H89\">H89: Using the title attribute to provide context-sensitive help</a>\n            </li>\n         </ul>"
+                "advisory": [
+                  {
+                    "id": "H89",
+                    "technology": "html",
+                    "title": "Using the title attribute to provide context-sensitive help"
+                  }
+                ]
               }
             },
             {
@@ -2635,8 +6316,12 @@
                   ]
                 }
               ],
-              "techniquesHtml": {
-                "sufficient": "<ul>\n            <li>\n               \tFollowing the \n               <a href=\"error-prevention-legal-financial-data#techniques\" class=\"understanding\">sufficient techniques for Success Criterion 3.3.4</a> for all forms that require the user to submit information.\n            </li>\n         </ul>"
+              "techniques": {
+                "sufficient": [
+                  {
+                    "title": "Following the <a href=\"https://www.w3.org/WAI/WCAG22/Understanding/error-prevention-legal-financial-data#techniques\">sufficient techniques for Success Criterion 3.3.4</a> for all forms that require the user to submit information"
+                  }
+                ]
               }
             },
             {
@@ -2680,8 +6365,17 @@
                   ]
                 }
               ],
-              "techniquesHtml": {
-                "sufficient": "<ul>\n            <li><a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G221\">G221: Provide data from a previous step in a process</a></li>\n            <li>Not requesting the same information twice (Potential future technique)</li>\n         </ul>"
+              "techniques": {
+                "sufficient": [
+                  {
+                    "id": "G221",
+                    "technology": "general",
+                    "title": "Provide data from a previous step in a process"
+                  },
+                  {
+                    "title": "Not requesting the same information twice (Potential future technique)"
+                  }
+                ]
               }
             },
             {
@@ -2727,9 +6421,35 @@
                   "text": "Examples of mechanisms that satisfy this criterion include: <ul> <li>support for password entry by password managers to reduce memory need, and</li> <li>copy and paste to reduce the cognitive burden of re-typing.</li> </ul>"
                 }
               ],
-              "techniquesHtml": {
-                "sufficient": "<ul>\n            <li>\n                <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G218\">G218: Email link authentication</a>\n            </li>\n            <li>\n                <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/html/H100\">H100: Providing properly marked up email and password inputs</a>\n            </li>\n            <li>\n                Providing WebAuthn as an alternative to username/password (Potential future technique)\n            </li>\n            <li>\n                Providing a 3rd party login using OAuth (Potential future technique)\n            </li>\n            <li>\n                Using two techniques to provide 2 factor authentication (Potential future technique)\n            </li>\n        </ul>",
-                "failure": "<ul>\n            <li>\n                <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/failures/F109\">F109: Failure of Success Criterion 3.3.8 and 3.3.9 due to preventing password or code re-entry in the same format</a>\n            </li>\n        </ul>"
+              "techniques": {
+                "sufficient": [
+                  {
+                    "id": "G218",
+                    "technology": "general",
+                    "title": "Email link authentication"
+                  },
+                  {
+                    "id": "H100",
+                    "technology": "html",
+                    "title": "Providing properly marked up email and password inputs"
+                  },
+                  {
+                    "title": "Providing WebAuthn as an alternative to username/password (Potential future technique)"
+                  },
+                  {
+                    "title": "Providing a third-party login using OAuth (Potential future technique)"
+                  },
+                  {
+                    "title": "Using two techniques to provide two-factor authentication (Potential future technique)"
+                  }
+                ],
+                "failure": [
+                  {
+                    "id": "F109",
+                    "technology": "failures",
+                    "title": "Failure of Success Criterion 3.3.8 and 3.3.9 due to preventing password or code re-entry in the same format"
+                  }
+                ]
               }
             },
             {
@@ -2757,9 +6477,35 @@
                   ]
                 }
               ],
-              "techniquesHtml": {
-                "sufficient": "<ul>\n            <li>\n                <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G218\">G218: Email link authentication</a>\n            </li>\n            <li>\n                <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/html/H100\">H100: Providing properly marked up email and password inputs</a>\n            </li>\n            <li>\n                Providing WebAuthn as an alternative to username/password (Potential future technique)\n            </li>\n            <li>\n                Providing a 3rd party login using OAuth (Potential future technique)\n            </li>\n            <li>\n                Using two techniques to provide 2 factor authentication (Potential future technique)\n            </li>\n        </ul>",
-                "failure": "<ul>\n            <li>\n                <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/failures/F109\">F109: Failure of Success Criterion 3.3.8 and 3.3.9 due to preventing password or code re-entry in the same format</a>\n            </li>\n        </ul>"
+              "techniques": {
+                "sufficient": [
+                  {
+                    "id": "G218",
+                    "technology": "general",
+                    "title": "Email link authentication"
+                  },
+                  {
+                    "id": "H100",
+                    "technology": "html",
+                    "title": "Providing properly marked up email and password inputs"
+                  },
+                  {
+                    "title": "Providing WebAuthn as an alternative to username/password (Potential future technique)"
+                  },
+                  {
+                    "title": "Providing a third-party login using OAuth (Potential future technique)"
+                  },
+                  {
+                    "title": "Using two techniques to provide two-factor authentication (Potential future technique)"
+                  }
+                ],
+                "failure": [
+                  {
+                    "id": "F109",
+                    "technology": "failures",
+                    "title": "Failure of Success Criterion 3.3.8 and 3.3.9 due to preventing password or code re-entry in the same format"
+                  }
+                ]
               }
             }
           ]
@@ -2816,7 +6562,7 @@
                   "text": "<p>Since this criterion was written, the HTML Living Standard has adopted specific requirements governing how user agents must handle incomplete tags, incorrect element nesting, duplicate attributes, and non-unique IDs. [<cite>HTML</cite>]</p> <p>Although the HTML standard treats some of these cases as non-conforming for authors, it is considered to \"allow these features\" for the purposes of this success criterion because the specification requires that user agents support handling these cases consistently. In practice, this criterion no longer provides any benefit to people with disabilities in itself.</p> <p>Issues such as missing roles due to inappropriately nested elements or incorrect states or names due to a duplicate ID are covered by different success criteria and should be reported under those criteria rather than as issues with 4.1.1.</p>"
                 }
               ],
-              "techniquesHtml": {}
+              "techniques": {}
             },
             {
               "id": "name-role-value",
@@ -2839,26 +6585,171 @@
                   "text": "This success criterion is primarily for web authors who develop or script their own user interface components. For example, standard <abbr title=\"HyperText Markup Language\">HTML</abbr> controls already meet this success criterion when used according to specification."
                 }
               ],
-              "techniquesHtml": {
+              "techniques": {
                 "sufficient": [
                   {
-                    "title": "Situation A: If using a standard user interface component in a markup language (e.g.,\n               HTML):",
-                    "content": "<ul>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/aria/ARIA14\">ARIA14: Using aria-label to provide an invisible label where a visible label cannot be used</a>\n               </li>\n               <li>\n                  <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/aria/ARIA16\">ARIA16: Using aria-labelledby to provide a name for user interface controls</a>\n               </li>\n               <li>\n                  <p>\n                     <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G108\">G108: Using markup features to expose the name and role, allow user-settable properties to be directly set, and provide notification of changes</a> using technology-specific techniques below:\n                  </p>\n                  <ul>\n                     <li>\n                        <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/html/H91\">H91: Using HTML form controls and links</a>\n                     </li>\n                     <li>\n                        <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/html/H44\">H44: Using label elements to associate text labels with form controls</a>\n                     </li>\n                     <li>\n                        <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/html/H64\">H64: Using the title attribute of the iframe element</a>\n                     </li>\n                     <li>\n                        <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/html/H65\">H65: Using the title attribute to identify form controls when the label element cannot be used</a>\n                     </li>\n                     <li>\n                        <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/html/H88\">H88: Using HTML according to spec</a>\n                     </li>\n                  </ul>\n               </li>\n            </ul>"
+                    "title": "Situation A: If using a standard user interface component in a markup language (e.g., HTML):",
+                    "techniques": [
+                      {
+                        "id": "ARIA14",
+                        "technology": "aria",
+                        "title": "Using aria-label to provide an invisible label where a visible label cannot be used"
+                      },
+                      {
+                        "id": "ARIA16",
+                        "technology": "aria",
+                        "title": "Using aria-labelledby to provide a name for user interface controls"
+                      },
+                      {
+                        "id": "G108",
+                        "technology": "general",
+                        "title": "Using markup features to expose the name and role, allow user-settable properties to be directly set, and provide notification of changes",
+                        "suffix": "using one or more of the following techniques:",
+                        "using": [
+                          {
+                            "id": "H91",
+                            "technology": "html",
+                            "title": "Using HTML form controls and links"
+                          },
+                          {
+                            "id": "H44",
+                            "technology": "html",
+                            "title": "Using label elements to associate text labels with form controls"
+                          },
+                          {
+                            "id": "H64",
+                            "technology": "html",
+                            "title": "Using the title attribute of the iframe element"
+                          },
+                          {
+                            "id": "H65",
+                            "technology": "html",
+                            "title": "Using the title attribute to identify form controls when the label element cannot be used"
+                          },
+                          {
+                            "id": "H88",
+                            "technology": "html",
+                            "title": "Using HTML according to spec"
+                          }
+                        ]
+                      }
+                    ]
                   },
                   {
-                    "title": "Situation B: If using script or code to re-purpose a standard user interface component\n               in a markup language:",
-                    "content": "<ul>\n               <li>\n                  <p>Exposing the names and roles, allowing user-settable properties to be directly set,\n                     and providing notification of changes using one of the following techniques:\n                  </p>\n                  <ul>\n                     <li>\n                        <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/aria/ARIA16\">ARIA16: Using aria-labelledby to provide a name for user interface controls</a>\n                     </li>\n                  </ul>\n               </li>\n            </ul>"
+                    "title": "Situation B: If using script or code to re-purpose a standard user interface component in a markup language:",
+                    "techniques": [
+                      {
+                        "title": "Exposing the names and roles, allowing user-settable properties to be directly set, and providing notification of changes",
+                        "suffix": "using one of the following techniques:",
+                        "using": [
+                          {
+                            "id": "ARIA16",
+                            "technology": "aria",
+                            "title": "Using aria-labelledby to provide a name for user interface controls"
+                          }
+                        ]
+                      }
+                    ]
                   },
                   {
                     "title": "Situation C: If using a standard user interface component in a programming technology:",
-                    "content": "<ul>\n               <li>\n                  <p>\n                     <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G135\">G135: Using the accessibility API features of a technology to expose names and roles, to allow user-settable properties to be directly set, and to provide notification of changes</a> using technology-specific techniques below:\n                  </p>\n                  <ul>\n                     <li>\n                        <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/pdf/PDF10\">PDF10: Providing labels for interactive form controls in PDF documents</a>\n                     </li>\n                     <li>\n                        <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/pdf/PDF12\">PDF12: Providing name, role, value information for form fields in PDF documents</a>\n                     </li>\n                  </ul>\n               </li>\n            </ul>"
+                    "techniques": [
+                      {
+                        "id": "G135",
+                        "technology": "general",
+                        "title": "Using the accessibility API features of a technology to expose names and roles, to allow user-settable properties to be directly set, and to provide notification of changes",
+                        "suffix": "using one or more of the following techniques:",
+                        "using": [
+                          {
+                            "id": "PDF10",
+                            "technology": "pdf",
+                            "title": "Providing labels for interactive form controls in PDF documents"
+                          },
+                          {
+                            "id": "PDF12",
+                            "technology": "pdf",
+                            "title": "Providing name, role, value information for form fields in PDF documents"
+                          }
+                        ]
+                      }
+                    ]
                   },
                   {
                     "title": "Situation D: If creating your own user interface component in a programming language:",
-                    "content": "<ul>\n               <li>\n                  <p>\n                     <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G10\">G10: Creating components using a technology that supports the accessibility API features of the platforms on which the user agents will be run to expose the names and roles, allow user-settable properties to be directly set, and provide notification of changes</a> using technology-specific techniques below:\n                  </p>\n                  <ul>\n                     <li>\n                        <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/aria/ARIA4\">ARIA4: Using a WAI-ARIA role to expose the role of a user interface component</a>\n                     </li>\n                     <li>\n                        <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/aria/ARIA5\">ARIA5: Using WAI-ARIA state and property attributes to expose the state of a user interface component</a>\n                     </li>\n                     <li>\n                        <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/aria/ARIA16\">ARIA16: Using aria-labelledby to provide a name for user interface controls</a>\n                     </li>\n                  </ul>\n               </li>\n            </ul>"
+                    "techniques": [
+                      {
+                        "id": "G10",
+                        "technology": "general",
+                        "title": "Creating components using a technology that supports the accessibility API features of the platforms on which the user agents will be run to expose the names and roles, allow user-settable properties to be directly set, and provide notification of changes",
+                        "suffix": "using one or more of the following techniques:",
+                        "using": [
+                          {
+                            "id": "ARIA4",
+                            "technology": "aria",
+                            "title": "Using a WAI-ARIA role to expose the role of a user interface component"
+                          },
+                          {
+                            "id": "ARIA5",
+                            "technology": "aria",
+                            "title": "Using WAI-ARIA state and property attributes to expose the state of a user interface component"
+                          },
+                          {
+                            "id": "ARIA16",
+                            "technology": "aria",
+                            "title": "Using aria-labelledby to provide a name for user interface controls"
+                          }
+                        ]
+                      }
+                    ]
                   }
                 ],
-                "failure": "<ul>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/failures/F59\">F59: Failure of Success Criterion 4.1.2 due to using script to make div or span a user interface control in HTML without providing a role for the control</a>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/failures/F15\">F15: Failure of Success Criterion 4.1.2 due to implementing custom controls that do not use an accessibility API for the technology, or do so incompletely</a>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/failures/F20\">F20: Failure of Success Criterion 1.1.1 and 4.1.2 due to not updating text alternatives when changes to non-text content occur</a>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/failures/F42\">F42: Failure of Success Criteria 1.3.1, 2.1.1, 2.1.3, or 4.1.2 when emulating links</a>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/failures/F68\">F68: Failure of Success Criterion 4.1.2 due to a user interface control not having a programmatically determined name </a>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/failures/F79\">F79: Failure of Success Criterion 4.1.2 due to the focus state of a user interface component not being programmatically determinable or no notification of change of focus state available</a>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/failures/F86\">F86: Failure of Success Criterion 4.1.2 due to not providing names for each part of a multi-part form field, such as a US telephone number</a>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/failures/F89\">F89: Failure of Success Criteria 2.4.4, 2.4.9 and 4.1.2 due to not providing an accessible name for an image which is the only content in a link</a>\n            </li>\n            <li>\n               <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/failures/F111\">F111: Failure of Success Criteria 1.3.1, 2.5.3, and 4.1.2 due to a control with visible label text but no accessible name</a>\n            </li>\n         </ul>"
+                "failure": [
+                  {
+                    "id": "F59",
+                    "technology": "failures",
+                    "title": "Failure of Success Criterion 4.1.2 due to using script to make div or span a user interface control in HTML without providing a role for the control"
+                  },
+                  {
+                    "id": "F15",
+                    "technology": "failures",
+                    "title": "Failure of Success Criterion 4.1.2 due to implementing custom controls that do not use an accessibility API for the technology, or do so incompletely"
+                  },
+                  {
+                    "id": "F20",
+                    "technology": "failures",
+                    "title": "Failure of Success Criterion 1.1.1 and 4.1.2 due to not updating text alternatives when changes to non-text content occur"
+                  },
+                  {
+                    "id": "F42",
+                    "technology": "failures",
+                    "title": "Failure of Success Criteria 1.3.1, 2.1.1, 2.1.3, or 4.1.2 when emulating links"
+                  },
+                  {
+                    "id": "F68",
+                    "technology": "failures",
+                    "title": "Failure of Success Criterion 4.1.2 due to a user interface control not having a programmatically determined name"
+                  },
+                  {
+                    "id": "F79",
+                    "technology": "failures",
+                    "title": "Failure of Success Criterion 4.1.2 due to the focus state of a user interface component not being programmatically determinable or no notification of change of focus state available"
+                  },
+                  {
+                    "id": "F86",
+                    "technology": "failures",
+                    "title": "Failure of Success Criterion 4.1.2 due to not providing names for each part of a multi-part form field, such as a US telephone number"
+                  },
+                  {
+                    "id": "F89",
+                    "technology": "failures",
+                    "title": "Failure of Success Criteria 2.4.4, 2.4.9 and 4.1.2 due to not providing an accessible name for an image which is the only content in a link"
+                  },
+                  {
+                    "id": "F111",
+                    "technology": "failures",
+                    "title": "Failure of Success Criteria 1.3.1, 2.5.3, and 4.1.2 due to a control with visible label text but no accessible name"
+                  }
+                ]
               }
             },
             {
@@ -2873,23 +6764,129 @@
               ],
               "level": "AA",
               "details": [],
-              "techniquesHtml": {
+              "techniques": {
                 "sufficient": [
                   {
                     "title": "Situation A: If a status message advises on the success or results of an action, or the state of an application:",
-                    "content": "<ul>\n\t\t\t\t\t\t<li><a href=\"https://www.w3.org/WAI/WCAG22/Techniques/aria/ARIA22\">ARIA22: Using role=status to present status messages</a> in combination with any of the following:\n\t\t\t\t\t\t\t<ul>\n\t\t\t\t\t\t\t\t<li><a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G199\">G199: Providing success feedback when data is submitted successfully</a></li>\n\t\t\t\t\t\t\t</ul>\n\t\t\t\t\t\t</li>\n\t\t\t\t\t</ul>"
+                    "techniques": [
+                      {
+                        "id": "ARIA22",
+                        "technology": "aria",
+                        "title": "Using role=status to present status messages",
+                        "suffix": "in combination with any of the following techniques:",
+                        "using": [
+                          {
+                            "id": "G199",
+                            "technology": "general",
+                            "title": "Providing success feedback when data is submitted successfully"
+                          }
+                        ]
+                      }
+                    ]
                   },
                   {
                     "title": "Situation B: If a status message conveys a suggestion, or a warning on the existence of an error:",
-                    "content": "<ul>\n\t\t\t\t\t\t<li><a href=\"https://www.w3.org/WAI/WCAG22/Techniques/aria/ARIA19\">ARIA19: Using ARIA role=alert or Live Regions to Identify Errors</a> in combination with any of the following:\n\t\t\t\t\t\t\t<ul>\n\t\t\t\t\t\t\t\t<li><a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G83\">G83: Providing text descriptions to identify required fields that were not completed</a></li>\n\t\t\t\t\t\t\t\t<li><a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G84\">G84: Providing a text description when the user provides information that is not in the list of allowed values</a></li>\n\t\t\t\t\t\t\t\t<li><a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G85\">G85: Providing a text description when user input falls outside the required format or values</a></li>\n\t\t\t\t\t\t\t\t<li><a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G177\">G177: Providing suggested correction text</a></li>\n\t\t\t\t\t\t\t\t<li><a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G194\">G194: Providing spell checking and suggestions for text input</a></li>\n\t\t\t\t\t\t\t</ul>\n\t\t\t\t\t\t</li>\n\t\t\t\t\t</ul>\n\t\t\t\t\t<p class=\"note\">\n\t\t\t\t<em>Note:</em>\n\t\t\t\tNot all examples in the preceding general techniques use status messages to convey warnings or errors to users. A role of \"alert\" is only necessary where a change of context does <em>not</em> take place.\n\t\t\t</p>"
+                    "techniques": [
+                      {
+                        "id": "ARIA19",
+                        "technology": "aria",
+                        "title": "Using ARIA role=alert or Live Regions to Identify Errors",
+                        "suffix": "in combination with any of the following techniques:",
+                        "using": [
+                          {
+                            "id": "G83",
+                            "technology": "general",
+                            "title": "Providing text descriptions to identify required fields that were not completed"
+                          },
+                          {
+                            "id": "G84",
+                            "technology": "general",
+                            "title": "Providing a text description when the user provides information that is not in the list of allowed values"
+                          },
+                          {
+                            "id": "G85",
+                            "technology": "general",
+                            "title": "Providing a text description when user input falls outside the required format or values"
+                          },
+                          {
+                            "id": "G177",
+                            "technology": "general",
+                            "title": "Providing suggested correction text"
+                          },
+                          {
+                            "id": "G194",
+                            "technology": "general",
+                            "title": "Providing spell checking and suggestions for text input"
+                          }
+                        ]
+                      }
+                    ],
+                    "note": "Not all examples in the preceding general techniques use status messages to convey warnings or errors to users. A role of \"alert\" is only necessary where a change of context does <em>not</em> take place."
                   },
                   {
                     "title": "Situation C: If a status message conveys information on the progress of a process:",
-                    "content": "<ul>\n\t\t\t\t\t\t<li><a href=\"https://www.w3.org/WAI/WCAG22/Techniques/aria/ARIA23\">ARIA23: Using role=log to identify sequential information updates</a></li>\n\t\t\t\t\t\t<li>Using <code>role=\"progressbar\"</code> (future link)</li>\n\t\t\t\t\t\t<li><a href=\"https://www.w3.org/WAI/WCAG22/Techniques/aria/ARIA22\">ARIA22: Using role=status to present status messages</a> in combination with <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/general/G193\">G193: Providing help by an assistant in the web page</a></li>\n\t\t\t\t\t</ul>"
+                    "techniques": [
+                      {
+                        "id": "ARIA23",
+                        "technology": "aria",
+                        "title": "Using role=log to identify sequential information updates"
+                      },
+                      {
+                        "title": "Using <code>role=\"progressbar\"</code> (future link)"
+                      },
+                      {
+                        "and": [
+                          {
+                            "id": "ARIA22",
+                            "technology": "aria",
+                            "title": "Using role=status to present status messages"
+                          },
+                          {
+                            "id": "G193",
+                            "technology": "general",
+                            "title": "Providing help by an assistant in the web page"
+                          }
+                        ]
+                      }
+                    ]
                   }
                 ],
-                "advisory": "<ul>\n\t\t<li>Using aria-live regions with chat clients (future link)</li>\n\t\t<li>Using aria-live regions to support <a href=\"content-on-hover-or-focus\">1.4.13 Content on Hover or Focus</a> (future link)</li>\n\t\t<li>Using <code>role=\"marquee\"</code> (future link)</li>\n\t\t<li>Using <code>role=\"timer\"</code> (future link)</li>\n\t\t\t\t\t<li>Where appropriate, moving focus to new content with <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/aria/ARIA18\">ARIA18: Using aria-alertdialog to Identify Errors</a></li>\n\t\t\t\t\t<li>Supporting personalization with <a href=\"https://www.w3.org/WAI/WCAG22/Techniques/client-side-script/SCR14\">SCR14: Using scripts to make nonessential alerts optional</a></li>\t\n\t</ul>",
-                "failure": "<ul>\n\t\t\t\t\t\t<li><a href=\"https://www.w3.org/WAI/WCAG22/Techniques/failures/F103\">F103: Failure of Success Criterion 4.1.3 due to providing status messages that cannot be programmatically determined through role or properties</a></li>\n\t\t\t\t<li>Using <code>role=\"alert\"</code> or <code>aria-live=\"assertive\"</code> on content which is not important and time-sensitive (future link)</li>\n\t\t\t</ul>"
+                "advisory": [
+                  {
+                    "title": "Using aria-live regions with chat clients (future link)"
+                  },
+                  {
+                    "title": "Using aria-live regions to support <a href=\"https://www.w3.org/WAI/WCAG22/Understanding/content-on-hover-or-focus\">1.4.13 Content on Hover or Focus</a> (future link)"
+                  },
+                  {
+                    "title": "Using <code>role=\"marquee\"</code> (future link)"
+                  },
+                  {
+                    "title": "Using <code>role=\"timer\"</code> (future link)"
+                  },
+                  {
+                    "id": "ARIA18",
+                    "technology": "aria",
+                    "title": "Using aria-alertdialog to Identify Errors",
+                    "prefix": "Where appropriate, moving focus to new content with"
+                  },
+                  {
+                    "id": "SCR14",
+                    "technology": "client-side-script",
+                    "title": "Using scripts to make nonessential alerts optional",
+                    "prefix": "Supporting personalization with"
+                  }
+                ],
+                "failure": [
+                  {
+                    "id": "F103",
+                    "technology": "failures",
+                    "title": "Failure of Success Criterion 4.1.3 due to providing status messages that cannot be programmatically determined through role or properties"
+                  },
+                  {
+                    "title": "Using <code>role=\"alert\"</code> or <code>aria-live=\"assertive\"</code> on content which is not important and time-sensitive (future link)"
+                  }
+                ]
               }
             }
           ]

--- a/_includes/sc.html
+++ b/_includes/sc.html
@@ -43,9 +43,9 @@
       <a href="{{site.understandingurl}}{{sc_id}}.html" class="btn btn-default btn-sm"><svg aria-hidden="true" class="i-info"><use xlink:href="{{ "img/icons.svg" | relative_url }}#i-info"></use></svg> Understanding {{ sc.num }}</a>
     </div>
   </div>
-  {% assign stech = sc.techniquesHtml.sufficient %}
-  {% assign atech = sc.techniquesHtml.advisory %}
-  {% assign ftech = sc.techniquesHtml.failure %}
+  {% assign stech = sc.techniques.sufficient %}
+  {% assign atech = sc.techniques.advisory %}
+  {% assign ftech = sc.techniques.failure %}
   {% if stech or atech or ftech %}
     <div class="techniques-button btn-group" role="group">
       <button data-target="#techniques-{{ sc_number }}" type="button" data-toggle="collapse" data-expanded="false" aria-controls="techniques-{{ sc_number }}" class="btn btn-info btn-techniques"><span class="word-show"><svg aria-hidden="true" class="i-chevron-right"><use xlink:href="{{ "img/icons.svg" | relative_url }}#i-chevron-right"></use></svg> Show</span><span class="word-hide"><svg aria-hidden="true" class="i-chevron-down"><use xlink:href="{{ "img/icons.svg" | relative_url }}#i-chevron-down"></use></svg> Hide</span> techniques and failures for {{ sc.num }}</button>
@@ -55,24 +55,46 @@
         <div class="tab-wrap">
           <div class="tab-content">
             {% if stech %}
-              {% assign theadid = "sc-" |append: sc_number | append: "-sufficient-head" %}
+              {% assign theadid = "sc-" | append: sc_number | append: "-sufficient-head" %}
               {% assign theadtitle = "Sufficient Techniques <span class='sr-only'>for Success Criterion " | append: sc.num | append: "</span>" %}
               <section class="tbox tbox-sufficient tab-pane active" id="sc-{{ sc_number }}-sufficient" data-historicalid="{% for aid in sc.alt_id %}{{aid}}-sufficient-head {% endfor %}" aria-labelledby="{{ theadid }}">
-                {% include techlist.html techtitle=theadtitle techheadid=theadid  techniques=stech ttype="sufficient" %}
+                <div class="panel panel-default">
+                  <div class="panel-heading"><h5 id="{{techheadid}}">{{theadtitle}}</h5></div>
+                  <div class="panel-body">
+                    <p>
+                      Note: Other techniques may also be sufficient if they meet the success criterion.
+                      See <a href="https://www.w3.org/WAI/WCAG22/Understanding/understanding-techniques" class="abouttech">Understanding Techniques.</a>
+                    </p>
+                    {% include techsection.html techniques=stech %}
+                    {% if sc.techniques.sufficientNote -%}
+                      {% include technote.html note=sc.techniques.sufficientNote %}
+                    {%- endif %}
+                  </div>
+                </div>
               </section>
             {% endif %}
             {% if atech %}
-              {% assign theadid = "sc-" |append: sc_number | append: "-advisory-head" %}
+              {% assign theadid = "sc-" | append: sc_number | append: "-advisory-head" %}
               {% assign theadtitle = "Advisory Techniques <span class='sr-only'>for Success Criterion " | append: sc.num | append: "</span>" %}
               <section class="tbox tbox-advisory tab-pane active" id="sc-{{ sc_number }}-advisory" data-historicalid="{% for aid in sc.alt_id %}{{aid}}-tech-optional-head {% endfor %}" aria-labelledby="{{ theadid }}">
-                {% include techlist.html techtitle=theadtitle techheadid=theadid techniques=atech ttype="advisory" %}
+                <div class="panel panel-default">
+                  <div class="panel-heading"><h5 id="{{techheadid}}">{{theadtitle}}</h5></div>
+                  <div class="panel-body">
+                    {% include techsection.html techniques=atech %}
+                  </div>
+                </div>
               </section>
             {% endif %}
             {% if ftech %}
-              {% assign theadid = "sc-" |append: sc_number | append: "-failures-head" %}
+              {% assign theadid = "sc-" | append: sc_number | append: "-failures-head" %}
               {% assign theadtitle = "Failures <span class='sr-only'>for Success Criterion " | append: sc.num | append: "</span>" %}
               <section class="tbox tbox-failures tab-pane active" id="sc-{{ sc_number }}-failures" data-historicalid="{% for aid in sc.alt_id %}{{aid}}-failures-head {% endfor %}" aria-labelledby="{{ theadid }}">
-                {% include techlist.html techtitle=theadtitle techheadid=theadid techniques=ftech ttype="failure" %}
+                <div class="panel panel-default">
+                  <div class="panel-heading"><h5 id="{{techheadid}}">{{theadtitle}}</h5></div>
+                  <div class="panel-body">
+                    {% include techsection.html techniques=ftech %}
+                  </div>
+                </div>
               </section>
             {% endif %}
           </div>

--- a/_includes/techentry.html
+++ b/_includes/techentry.html
@@ -4,37 +4,9 @@ Expected input:
 - technique = technique object
 {%- endcomment -%}
 
-{%- assign code = include.technique.id | replace: "1" , "" | replace:"2","" | replace:"3","" | replace:"4","" | replace:"5","" | replace:"6","" | replace:"7","" | replace:"8","" | replace:"9","" | replace:"0","" -%}
-{%- case code -%}
-  {%- when 'ARIA' %}
-    {%- assign techslug = "aria" -%}
-  {%- when 'SCR' %}
-    {%- assign techslug = "client-side-script" -%}
-  {%- when 'C' %}
-    {%- assign techslug = "css" -%}
-  {%- when 'F' %}
-    {%- assign techslug = "failures" -%}
-  {%- when 'FLASH' %}
-    {%- assign techslug = "flash" -%}
-  {%- when 'G' %}
-    {%- assign techslug = "general" -%}
-  {%- when 'H' %}
-    {%- assign techslug = "html" -%}
-  {%- when 'PDF' %}
-    {%- assign techslug = "pdf" -%}
-  {%- when 'SVR' %}
-    {%- assign techslug = "server-side-script" -%}
-  {%- when 'SL' %}
-    {%- assign techslug = "silverlight" -%}
-  {%- when 'SM' %}
-    {%- assign techslug = "smil" -%}
-  {%- when 'T' %}
-    {%- assign techslug = "text" -%}
-{%- endcase -%}
-
 {%- if include.technique.prefix %}{{ include.technique.prefix }} {% endif -%}
 {%- if include.technique.id -%}
-  <a href="{{ site.techniqueurl }}{{ techslug }}/{{ include.technique.id }}">
+  <a href="{{ site.techniqueurl }}{{ include.technique.technology }}/{{ include.technique.id }}">
     {{- include.technique.id }}: {{ include.technique.title -}}
   </a>
 {%- else -%}

--- a/_includes/techentry.html
+++ b/_includes/techentry.html
@@ -1,0 +1,43 @@
+{%- comment -%}
+Handles formatting for a single technique (no `using` or `and` handling).
+Expected input:
+- technique = technique object
+{%- endcomment -%}
+
+{%- assign code = include.technique.id | replace: "1" , "" | replace:"2","" | replace:"3","" | replace:"4","" | replace:"5","" | replace:"6","" | replace:"7","" | replace:"8","" | replace:"9","" | replace:"0","" -%}
+{%- case code -%}
+  {%- when 'ARIA' %}
+    {%- assign techslug = "aria" -%}
+  {%- when 'SCR' %}
+    {%- assign techslug = "client-side-script" -%}
+  {%- when 'C' %}
+    {%- assign techslug = "css" -%}
+  {%- when 'F' %}
+    {%- assign techslug = "failures" -%}
+  {%- when 'FLASH' %}
+    {%- assign techslug = "flash" -%}
+  {%- when 'G' %}
+    {%- assign techslug = "general" -%}
+  {%- when 'H' %}
+    {%- assign techslug = "html" -%}
+  {%- when 'PDF' %}
+    {%- assign techslug = "pdf" -%}
+  {%- when 'SVR' %}
+    {%- assign techslug = "server-side-script" -%}
+  {%- when 'SL' %}
+    {%- assign techslug = "silverlight" -%}
+  {%- when 'SM' %}
+    {%- assign techslug = "smil" -%}
+  {%- when 'T' %}
+    {%- assign techslug = "text" -%}
+{%- endcase -%}
+
+{%- if include.technique.prefix %}{{ include.technique.prefix }} {% endif -%}
+{%- if include.technique.id -%}
+  <a href="{{ site.techniqueurl }}{{ techslug }}/{{ include.technique.id }}">
+    {{- include.technique.id }}: {{ include.technique.title -}}
+  </a>
+{%- else -%}
+  {{ include.technique.title }}
+{%- endif -%}
+{%- if include.technique.suffix %} {{ include.technique.suffix }}{% endif -%}

--- a/_includes/techlist.html
+++ b/_includes/techlist.html
@@ -1,20 +1,22 @@
-<div class="panel panel-default">
-  <div class="panel-heading">
-    <h5 id="{{include.techheadid}}">
-      {{include.techtitle}}
-    </h5>
-  </div>
-  {% if include.ttype == 'sufficient' %}
-    <div class="panel-body">
-      <p>Note: Other techniques may also be sufficient if they meet the success criterion. See <a href="https://www.w3.org/WAI/WCAG22/Understanding/understanding-techniques" class="abouttech">Understanding Techniques.</a></p>
-    </div>
-  {% endif %}
-  <div class="panel-body">
-    {% if include.techniques[0] %}{% for situation in include.techniques %}
-      <div class="panel panel-default">
-        <div class="panel-heading"><h6>{{situation.title}}</h6></div>
-        <div class="panel-body">{{situation.content}}</div>
-      </div>
-    {% endfor %}{% else %}{{include.techniques}}{% endif %}
-  </div>
-</div>
+{%- comment -%}
+Expected inputs:
+- techniques = Array of technique objects or shorthand strings
+{%- endcomment -%}
+
+<ul>
+{% for technique in include.techniques %}
+  <li>
+    {%- if technique.and -%}
+      {%- for andEntry in technique.and %}
+        {% unless forloop.first %} <strong>AND</strong> {% endunless %}
+        {% include techentry.html technique=andEntry %}
+      {%- endfor -%}
+    {%- else -%}
+      {% include techentry.html technique=technique %}
+    {%- endif -%}
+    {%- if technique.using %}
+      {% include techlist.html techniques=technique.using %}
+    {% endif -%}
+  </li>
+{% endfor %}
+</ul>

--- a/_includes/technote.html
+++ b/_includes/technote.html
@@ -1,0 +1,13 @@
+{%- comment -%}
+Expected input:
+- note = Text or HTML containing note text.
+If note begins with an HTML element, it will be rendered inside of a div;
+otherwise, it will be treated as flow content and rendered inside of a p.
+{%- endcomment -%}
+
+{%- assign strippedNote = include.note | strip %}
+{%- assign noteStart = strippedNote | slice: 0 -%}
+{%- capture noteTag %}{% if noteStart == "<" %}div{% else %}p{% endif %}{% endcapture %}
+<{{ noteTag }} class="note">
+  <em>Note:</em> {{ strippedNote }}
+</{{ noteTag }}>

--- a/_includes/techsection.html
+++ b/_includes/techsection.html
@@ -1,0 +1,22 @@
+{%- comment -%}
+Expected inputs:
+- techniques = Array of top-level technique objects / shorthand strings, or subsections
+{%- endcomment -%}
+
+{% if include.techniques[0].techniques %}
+  {% for section in include.techniques %}
+    <div class="panel panel-default">
+      <div class="panel-heading"><h6>{{ section.title }}</h6></div>
+      <div class="panel-body">
+        {% include techlist.html techniques=section.techniques groups=section.groups %}
+        {% for group in section.groups %}
+          <p role="heading" aria-level="7">{{ group.title }}:</p>
+          {% include techlist.html techniques=group.techniques %}
+        {% endfor %}
+        {% if section.note %}{% include technote.html note=section.note %}{% endif %}
+      </div>
+    </div>
+  {% endfor %}
+{% else %}
+  {% include techlist.html techniques=include.techniques %}
+{% endif %}

--- a/_scripts/update-wcag-json.mjs
+++ b/_scripts/update-wcag-json.mjs
@@ -19,7 +19,7 @@ const data = { principles: wcag22.principles };
 // Incorporate 2.1's version of 4.1.1 Parsing, but remove techniques
 data.principles[3].guidelines[0].successcriteria[0] =
   wcag21.principles[3].guidelines[0].successcriteria[0];
-data.principles[3].guidelines[0].successcriteria[0].techniquesHtml = {};
+data.principles[3].guidelines[0].successcriteria[0].techniques = {};
 
 // Prune unneeded fields
 for (const principle of data.principles) {


### PR DESCRIPTION
This applies the update from https://github.com/w3c/wcag/pull/4619 to wcag22.json in Quickref, and updates templates to use it - with far less code than what had been required prior to #274.